### PR TITLE
perf(processors): remove unnecessary frame copy in post-processing

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -316,7 +316,7 @@ def get_faces_optimized(frame: Frame, use_cache: bool = True) -> Optional[List[F
 # --- START: Helper function for interpolation and sharpening ---
 def apply_post_processing(current_frame: Frame, swapped_face_bboxes: List[np.ndarray]) -> Frame:
     """Applies sharpening and interpolation with Apple Silicon optimizations."""
-    processed_frame = current_frame.copy()
+    processed_frame = current_frame
 
     # 1. Apply Sharpening (if enabled) with optimized kernel for Apple Silicon
     sharpness_value = getattr(modules.globals, "sharpness", 0.0)


### PR DESCRIPTION
## Summary

- Removes `current_frame.copy()` at the start of `apply_post_processing()` — the original frame is not read again after this point
- Saves one full frame allocation + memcpy per processed frame

## Test plan

- [ ] Run realtime faceswap with sharpening enabled — confirm output is unchanged
- [ ] Run realtime faceswap for ≥15 min — verify no FPS regression or artifacts

Closes #4