### PR TITLE
perf(face-swapper): set CoreML ModelCacheDirectory to avoid recompilation on restart

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -93,6 +93,8 @@ def get_face_swapper() -> Any:
                     for p in modules.globals.execution_providers:
                         if p == "CoreMLExecutionProvider" and IS_APPLE_SILICON:
                             # Enhanced CoreML configuration for M1-M5
+                            coreml_cache_dir = os.path.join(os.path.expanduser("~"), ".cache", "deep-live-cam", "coreml")
+                            os.makedirs(coreml_cache_dir, exist_ok=True)
                             providers_config.append((
                                 "CoreMLExecutionProvider",
                                 {
@@ -103,6 +105,7 @@ def get_face_swapper() -> Any:
                                     "EnableOnSubgraphs": 1,
                                     "RequireStaticShapes": 1,
                                     "MaximumCacheSize": 1024 * 1024 * 512,  # 512MB cache
+                                    "ModelCacheDirectory": coreml_cache_dir,
                                 }
                             ))
                         else:


### PR DESCRIPTION
## Summary

- Sets `ModelCacheDirectory` to `~/.cache/deep-live-cam/coreml` in the `CoreMLExecutionProvider` options
- On subsequent restarts, CoreML finds previously compiled `.mlmodelc` artifacts and skips recompilation, eliminating the multi-second startup delay
- Directory is created with `os.makedirs(..., exist_ok=True)` before session creation

## Test plan

- [ ] Launch with `just start` on Apple Silicon — first launch compiles and caches
- [ ] Restart — confirm startup is noticeably faster (no recompilation)
- [ ] Verify `~/.cache/deep-live-cam/coreml/` is populated after first run

Closes #5