### PR TITLE
feat: half-rate face processing with RIFE temporal upscaling

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -64,6 +64,8 @@ def parse_args() -> None:
     program.add_argument('--rife', help='enable RIFE frame interpolation for video output', dest='rife_enabled', action='store_true', default=False)
     program.add_argument('--rife-model', help='RIFE model to use', dest='rife_model', default='rife-v4.25-lite', choices=['rife-v4.25', 'rife-v4.25-lite'])
     program.add_argument('--rife-multiplier', help='RIFE frame rate multiplier (2=double, 4=quadruple)', dest='rife_multiplier', type=int, default=2, choices=[2, 4])
+    program.add_argument('--half-rate', help='enable half-rate face processing with RIFE interpolation for live mode', dest='half_rate_processing', action='store_true', default=False)
+    program.add_argument('--keyframe-interval', help='process every Nth frame in half-rate mode (2-10)', dest='keyframe_interval', type=int, default=2, choices=range(2, 11))
     program.add_argument('--max-memory', help='maximum amount of RAM in GB', dest='max_memory', type=int, default=suggest_max_memory())
     program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=['cpu'], choices=suggest_execution_providers(), nargs='+')
     program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
@@ -101,6 +103,8 @@ def parse_args() -> None:
     modules.globals.rife_enabled = args.rife_enabled
     modules.globals.rife_model = args.rife_model
     modules.globals.rife_multiplier = args.rife_multiplier
+    modules.globals.half_rate_processing = args.half_rate_processing
+    modules.globals.keyframe_interval = args.keyframe_interval
 
     #for ENHANCER tumblers:
     for enhancer_key in ('face_enhancer', 'face_enhancer_gpen256', 'face_enhancer_gpen512'):

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -93,4 +93,8 @@ rife_enabled: bool = False            # Toggle RIFE frame interpolation for vide
 rife_model: str = "rife-v4.25-lite"   # Model to use: "rife-v4.25" or "rife-v4.25-lite"
 rife_multiplier: int = 2              # Frame rate multiplier: 2 = double fps, 4 = quadruple fps
 
+# --- Half-Rate Processing ---
+half_rate_processing: bool = False    # Process every Nth frame; use RIFE to fill skipped frames
+keyframe_interval: int = 2            # Run face processing every Nth frame (2-10)
+
 # --- END OF FILE globals.py ---

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -175,6 +175,8 @@ def save_switch_states():
         "rife_enabled": modules.globals.rife_enabled,
         "rife_model": modules.globals.rife_model,
         "rife_multiplier": modules.globals.rife_multiplier,
+        "half_rate_processing": modules.globals.half_rate_processing,
+        "keyframe_interval": modules.globals.keyframe_interval,
         "source_path": modules.globals.source_path,
         "target_path": modules.globals.target_path,
     }
@@ -206,6 +208,8 @@ def load_switch_states():
         modules.globals.rife_enabled = switch_states.get("rife_enabled", False)
         modules.globals.rife_model = switch_states.get("rife_model", "rife-v4.25-lite")
         modules.globals.rife_multiplier = switch_states.get("rife_multiplier", 2)
+        modules.globals.half_rate_processing = switch_states.get("half_rate_processing", False)
+        modules.globals.keyframe_interval = switch_states.get("keyframe_interval", 2)
         # Restore last-used paths; validate existence before accepting.
         saved_source = switch_states.get("source_path")
         if saved_source and os.path.isfile(saved_source):
@@ -341,6 +345,7 @@ def _get_switch_defs():
             (_("Fix Blueish Cam"), "color_correction", False),
             (_("Show FPS"), "show_fps", False),
             (_("Virtual Camera"), "virtual_cam", False),
+            (_("Half-Rate Processing"), "half_rate_processing", False),
         ],
     }
 
@@ -404,9 +409,10 @@ def _add_settings_tabview(root: ctk.CTk, live_button: ctk.CTkButton) -> None:
     output_tab = tabview.tab("Output")
     _add_rife_controls_to_tab(output_tab, len(switch_defs["Output"]))
 
-    # Live Mode tab: add camera dropdown (live button is in action bar)
+    # Live Mode tab: add camera dropdown and keyframe interval control
     live_tab = tabview.tab("Live Mode")
     _add_camera_to_tab(live_tab, root, len(switch_defs["Live Mode"]), live_button)
+    _add_half_rate_controls_to_tab(live_tab, len(switch_defs["Live Mode"]))
 
 
 def _add_sliders_to_tab(tab: ctk.CTkFrame, num_switches: int) -> None:
@@ -508,6 +514,34 @@ def _add_rife_controls_to_tab(tab: ctk.CTkFrame, num_switches: int) -> None:
     )
     multiplier_optionmenu.grid(
         row=start_row + 1, column=1, sticky="ew", padx=(0, 15), pady=2,
+    )
+
+
+def _add_half_rate_controls_to_tab(tab: ctk.CTkFrame, num_switches: int) -> None:
+    """Add keyframe interval dropdown to the Live Mode tab (below the camera selector)."""
+    # Camera selector occupies row (num_switches + 1) // 2 + 1; we start one below it
+    start_row = (num_switches + 1) // 2 + 2
+
+    interval_label = ctk.CTkLabel(tab, text="Keyframe Interval:")
+    interval_label.grid(row=start_row, column=0, sticky="w", padx=15, pady=(8, 2))
+
+    interval_values = ["2", "3", "4", "5", "8", "10"]
+    current_interval = str(getattr(modules.globals, "keyframe_interval", 2))
+    if current_interval not in interval_values:
+        current_interval = "2"
+    interval_variable = ctk.StringVar(value=current_interval)
+
+    def on_interval_change(choice):
+        modules.globals.keyframe_interval = int(choice)
+        save_switch_states()
+        update_status(f"Keyframe interval set to every {choice} frames")
+
+    interval_optionmenu = ctk.CTkOptionMenu(
+        tab, variable=interval_variable, values=interval_values,
+        command=on_interval_change,
+    )
+    interval_optionmenu.grid(
+        row=start_row, column=1, sticky="ew", padx=(0, 15), pady=(8, 2),
     )
 
 

--- a/modules/ui_webcam.py
+++ b/modules/ui_webcam.py
@@ -90,6 +90,8 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
     fps = 0
     prev_processed_frame = None
     rife_warned = False
+    half_rate_warned = False
+    frame_counter = 0
 
     while not stop_event.is_set():
         try:
@@ -106,70 +108,94 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
         with detection_lock:
             latest_frame_holder[0] = temp_frame
 
-        if not modules.globals.map_faces:
-            if modules.globals.source_path and modules.globals.source_path != last_source_path:
-                last_source_path = modules.globals.source_path
-                source_image = get_one_face(cv2.imread(modules.globals.source_path))
+        # Half-rate processing: run face processing only on keyframes
+        half_rate_enabled = getattr(modules.globals, "half_rate_processing", False)
+        keyframe_interval = max(2, getattr(modules.globals, "keyframe_interval", 2))
+        frame_counter += 1
+        is_keyframe = (frame_counter % keyframe_interval) == 1
+        skip_face_processing = half_rate_enabled and not is_keyframe
 
-            # Read latest detection results — brief lock copy so we don't
-            # block the detection thread longer than necessary
-            with detection_lock:
-                cached_target_face = detection_result.get('target_face')
-                cached_many_faces = detection_result.get('many_faces')
+        if not skip_face_processing:
+            if not modules.globals.map_faces:
+                if modules.globals.source_path and modules.globals.source_path != last_source_path:
+                    last_source_path = modules.globals.source_path
+                    source_image = get_one_face(cv2.imread(modules.globals.source_path))
 
-            # Build a face list from cached detection for enhancer reuse
-            cached_faces_list = None
-            if cached_many_faces:
-                cached_faces_list = cached_many_faces
-            elif cached_target_face is not None:
-                cached_faces_list = [cached_target_face]
+                # Read latest detection results — brief lock copy so we don't
+                # block the detection thread longer than necessary
+                with detection_lock:
+                    cached_target_face = detection_result.get('target_face')
+                    cached_many_faces = detection_result.get('many_faces')
 
-            for frame_processor in frame_processors:
-                if frame_processor.NAME == "DLC.FACE-ENHANCER":
-                    if modules.globals.fp_ui.get("face_enhancer"):
-                        temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
-                elif frame_processor.NAME == "DLC.FACE-ENHANCER-GPEN256":
-                    if modules.globals.fp_ui.get("face_enhancer_gpen256"):
-                        temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
-                elif frame_processor.NAME == "DLC.FACE-ENHANCER-GPEN512":
-                    if modules.globals.fp_ui.get("face_enhancer_gpen512"):
-                        temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
-                elif frame_processor.NAME == "DLC.FACE-SWAPPER":
-                    # Use cached face positions to skip redundant detection
-                    swapped_bboxes = []
-                    if modules.globals.many_faces and cached_many_faces:
-                        opacity = getattr(modules.globals, "opacity", 1.0)
-                        result = temp_frame if opacity >= 1.0 else temp_frame.copy()
-                        for t_face in cached_many_faces:
-                            result = frame_processor.swap_face(source_image, t_face, result)
-                            if hasattr(t_face, 'bbox') and t_face.bbox is not None:
-                                swapped_bboxes.append(t_face.bbox.astype(int))
-                        temp_frame = result
-                    elif cached_target_face is not None:
-                        temp_frame = frame_processor.swap_face(source_image, cached_target_face, temp_frame)
-                        if hasattr(cached_target_face, 'bbox') and cached_target_face.bbox is not None:
-                            swapped_bboxes.append(cached_target_face.bbox.astype(int))
-                    # Apply post-processing (sharpening, interpolation)
-                    temp_frame = frame_processor.apply_post_processing(temp_frame, swapped_bboxes)
-                else:
-                    temp_frame = frame_processor.process_frame(source_image, temp_frame)
+                # Build a face list from cached detection for enhancer reuse
+                cached_faces_list = None
+                if cached_many_faces:
+                    cached_faces_list = cached_many_faces
+                elif cached_target_face is not None:
+                    cached_faces_list = [cached_target_face]
+
+                for frame_processor in frame_processors:
+                    if frame_processor.NAME == "DLC.FACE-ENHANCER":
+                        if modules.globals.fp_ui.get("face_enhancer"):
+                            temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
+                    elif frame_processor.NAME == "DLC.FACE-ENHANCER-GPEN256":
+                        if modules.globals.fp_ui.get("face_enhancer_gpen256"):
+                            temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
+                    elif frame_processor.NAME == "DLC.FACE-ENHANCER-GPEN512":
+                        if modules.globals.fp_ui.get("face_enhancer_gpen512"):
+                            temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
+                    elif frame_processor.NAME == "DLC.FACE-SWAPPER":
+                        # Use cached face positions to skip redundant detection
+                        swapped_bboxes = []
+                        if modules.globals.many_faces and cached_many_faces:
+                            opacity = getattr(modules.globals, "opacity", 1.0)
+                            result = temp_frame if opacity >= 1.0 else temp_frame.copy()
+                            for t_face in cached_many_faces:
+                                result = frame_processor.swap_face(source_image, t_face, result)
+                                if hasattr(t_face, 'bbox') and t_face.bbox is not None:
+                                    swapped_bboxes.append(t_face.bbox.astype(int))
+                            temp_frame = result
+                        elif cached_target_face is not None:
+                            temp_frame = frame_processor.swap_face(source_image, cached_target_face, temp_frame)
+                            if hasattr(cached_target_face, 'bbox') and cached_target_face.bbox is not None:
+                                swapped_bboxes.append(cached_target_face.bbox.astype(int))
+                        # Apply post-processing (sharpening, interpolation)
+                        temp_frame = frame_processor.apply_post_processing(temp_frame, swapped_bboxes)
+                    else:
+                        temp_frame = frame_processor.process_frame(source_image, temp_frame)
+            else:
+                modules.globals.target_path = None
+                for frame_processor in frame_processors:
+                    if frame_processor.NAME == "DLC.FACE-ENHANCER":
+                        if modules.globals.fp_ui.get("face_enhancer"):
+                            temp_frame = frame_processor.process_frame_v2(temp_frame)
+                    elif frame_processor.NAME in ("DLC.FACE-ENHANCER-GPEN256", "DLC.FACE-ENHANCER-GPEN512"):
+                        fp_key = "face_enhancer_gpen256" if "256" in frame_processor.NAME else "face_enhancer_gpen512"
+                        if modules.globals.fp_ui.get(fp_key):
+                            temp_frame = frame_processor.process_frame_v2(temp_frame)
+                    else:
+                        temp_frame = frame_processor.process_frame(None, temp_frame)
         else:
-            modules.globals.target_path = None
-            for frame_processor in frame_processors:
-                if frame_processor.NAME == "DLC.FACE-ENHANCER":
-                    if modules.globals.fp_ui.get("face_enhancer"):
-                        temp_frame = frame_processor.process_frame_v2(temp_frame)
-                elif frame_processor.NAME in ("DLC.FACE-ENHANCER-GPEN256", "DLC.FACE-ENHANCER-GPEN512"):
-                    fp_key = "face_enhancer_gpen256" if "256" in frame_processor.NAME else "face_enhancer_gpen512"
-                    if modules.globals.fp_ui.get(fp_key):
-                        temp_frame = frame_processor.process_frame_v2(temp_frame)
+            # Skip frame: use RIFE to interpolate between the last keyframe and current raw frame
+            rife_for_skip = getattr(modules.globals, "rife_enabled", False)
+            if half_rate_enabled and not rife_for_skip:
+                if not half_rate_warned:
+                    print("[DLC.HALF-RATE] Half-rate processing requires RIFE — output will use raw frames on skips")
+                    half_rate_warned = True
+            elif rife_for_skip and prev_processed_frame is not None:
+                if not has_native_binding():
+                    if not half_rate_warned:
+                        print("[DLC.HALF-RATE] RIFE native binding not available — skip frames will use raw camera input")
+                        half_rate_warned = True
                 else:
-                    temp_frame = frame_processor.process_frame(None, temp_frame)
+                    intermediates = interpolate_frame_pair(prev_processed_frame, temp_frame, multiplier=2)
+                    if intermediates:
+                        temp_frame = intermediates[0]
 
-        # RIFE frame interpolation: emit intermediate frames between
-        # the previous processed frame and the current one.
+        # RIFE frame interpolation: emit intermediate frames between consecutive keyframes.
+        # Suppressed on half-rate skip frames (those are handled in the else-branch above).
         rife_enabled = getattr(modules.globals, "rife_enabled", False)
-        if rife_enabled and prev_processed_frame is not None:
+        if rife_enabled and prev_processed_frame is not None and not skip_face_processing:
             if not rife_warned and not has_native_binding():
                 print("[DLC.RIFE] Native binding not available — live interpolation disabled")
                 rife_warned = True
@@ -194,10 +220,13 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
                         except queue.Full:
                             pass
 
-        if rife_enabled:
-            prev_processed_frame = temp_frame.copy()
-        else:
-            prev_processed_frame = None
+        # Update prev_processed_frame on keyframes; keep unchanged on skip frames
+        if not skip_face_processing:
+            if rife_enabled or half_rate_enabled:
+                prev_processed_frame = temp_frame.copy()
+            else:
+                prev_processed_frame = None
+        # else (skip frame): prev_processed_frame stays set to the last keyframe output
 
         # Calculate and display FPS
         current_time = time.time()

--- a/tests/test_half_rate_processing.py
+++ b/tests/test_half_rate_processing.py
@@ -1,0 +1,346 @@
+"""Tests for half-rate face processing with RIFE temporal upscaling (Issue #29).
+
+Half-rate mode runs face processing only on every Nth frame (keyframes) and uses
+RIFE interpolation to fill in the skipped frames, trading face-processing compute
+for cheaper RIFE interpolation.
+"""
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+import modules.globals
+
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+
+
+class TestHalfRateGlobals:
+    """Test that half-rate globals exist with correct defaults."""
+
+    def test_half_rate_disabled_by_default(self):
+        assert hasattr(modules.globals, "half_rate_processing")
+        assert modules.globals.half_rate_processing is False
+
+    def test_keyframe_interval_default(self):
+        assert hasattr(modules.globals, "keyframe_interval")
+        assert modules.globals.keyframe_interval == 2
+
+    def test_keyframe_interval_is_int(self):
+        assert isinstance(modules.globals.keyframe_interval, int)
+
+    def test_half_rate_is_bool(self):
+        assert isinstance(modules.globals.half_rate_processing, bool)
+
+
+# ---------------------------------------------------------------------------
+# Keyframe interval range
+# ---------------------------------------------------------------------------
+
+
+class TestKeyframeIntervalRange:
+    """Validate keyframe_interval default is within the allowed 2-10 range."""
+
+    def test_keyframe_interval_minimum(self):
+        """keyframe_interval must be at least 2 (at least one skip frame)."""
+        assert modules.globals.keyframe_interval >= 2
+
+    def test_keyframe_interval_maximum(self):
+        """keyframe_interval must be at most 10 per CLI choices=range(2, 11)."""
+        assert modules.globals.keyframe_interval <= 10
+
+
+# ---------------------------------------------------------------------------
+# Keyframe selection logic
+# ---------------------------------------------------------------------------
+
+
+class TestKeyframeLogic:
+    """Unit-test the keyframe selection formula used in _processing_thread_func."""
+
+    @staticmethod
+    def _is_keyframe(frame_counter: int, keyframe_interval: int) -> bool:
+        """Replicate the keyframe logic from ui_webcam.py."""
+        return (frame_counter % keyframe_interval) == 1
+
+    @staticmethod
+    def _skip_face_processing(half_rate_enabled: bool, frame_counter: int, keyframe_interval: int) -> bool:
+        is_keyframe = (frame_counter % keyframe_interval) == 1
+        return half_rate_enabled and not is_keyframe
+
+    def test_interval_2_odd_frames_are_keyframes(self):
+        """With interval=2 frames 1,3,5,7,9 are keyframes; 2,4,6,8,10 are skips."""
+        for i in range(1, 11):
+            expected = (i % 2 == 1)
+            assert self._is_keyframe(i, 2) == expected, (
+                f"Frame {i} with interval=2: expected is_keyframe={expected}"
+            )
+
+    def test_interval_4_frames_1_5_9_are_keyframes(self):
+        assert self._is_keyframe(1, 4) is True
+        assert self._is_keyframe(2, 4) is False
+        assert self._is_keyframe(3, 4) is False
+        assert self._is_keyframe(4, 4) is False
+        assert self._is_keyframe(5, 4) is True
+        assert self._is_keyframe(9, 4) is True
+
+    def test_interval_3_frames_1_4_7_are_keyframes(self):
+        assert self._is_keyframe(1, 3) is True
+        assert self._is_keyframe(2, 3) is False
+        assert self._is_keyframe(3, 3) is False
+        assert self._is_keyframe(4, 3) is True
+        assert self._is_keyframe(7, 3) is True
+
+    def test_skip_processing_when_half_rate_on_skip_frame(self):
+        """skip_face_processing=True when half-rate enabled and frame is not a keyframe."""
+        assert self._skip_face_processing(True, 2, 2) is True
+
+    def test_no_skip_when_half_rate_disabled(self):
+        """skip_face_processing is always False when half-rate is disabled."""
+        for i in range(1, 11):
+            assert self._skip_face_processing(False, i, 2) is False
+
+    def test_no_skip_on_keyframe_with_half_rate_enabled(self):
+        """Keyframes are never skipped even in half-rate mode."""
+        assert self._skip_face_processing(True, 1, 2) is False  # frame 1 = keyframe
+
+
+# ---------------------------------------------------------------------------
+# Warning when RIFE unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestHalfRateRifeRequirement:
+    """Half-rate mode should warn when RIFE is unavailable, not crash."""
+
+    def test_warning_printed_when_rife_disabled(self, capsys):
+        """When half-rate=on and rife_enabled=False, a warning is logged on skip frames."""
+        half_rate_enabled = True
+        rife_enabled = False
+        half_rate_warned = False
+        frame_counter = 2        # skip frame for interval=2
+        keyframe_interval = 2
+        is_keyframe = (frame_counter % keyframe_interval) == 1
+        skip_face_processing = half_rate_enabled and not is_keyframe
+
+        # Replicate warning logic from _processing_thread_func else-branch
+        if skip_face_processing and half_rate_enabled and not rife_enabled:
+            if not half_rate_warned:
+                print(
+                    "[DLC.HALF-RATE] Half-rate processing requires RIFE "
+                    "— output will use raw frames on skips"
+                )
+                half_rate_warned = True
+
+        captured = capsys.readouterr()
+        assert "[DLC.HALF-RATE]" in captured.out
+        assert half_rate_warned is True
+
+    def test_warning_fires_only_once(self):
+        """The half_rate_warned flag prevents repeated warning prints."""
+        half_rate_warned = False
+        warning_count = 0
+
+        for _ in range(5):  # simulate 5 consecutive skip frames
+            if not half_rate_warned:
+                warning_count += 1
+                half_rate_warned = True
+
+        assert warning_count == 1
+
+
+# ---------------------------------------------------------------------------
+# RIFE interpolation on skip frames
+# ---------------------------------------------------------------------------
+
+
+class TestSkipFrameRifeInterpolation:
+    """Verify RIFE is called with (prev_processed, current_raw) on skip frames."""
+
+    @staticmethod
+    def _make_frame(fill: int = 0) -> np.ndarray:
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        frame[:] = fill
+        return frame
+
+    def test_rife_called_with_prev_processed_and_raw(self):
+        """interpolate_frame_pair receives (prev_processed_frame, raw_temp_frame)."""
+        prev_processed = self._make_frame(50)
+        raw_frame = self._make_frame(100)
+        interp_frame = self._make_frame(75)
+
+        with patch(
+            "modules.rife_interpolation.interpolate_frame_pair",
+            return_value=[interp_frame],
+        ) as mock_interp, patch(
+            "modules.rife_interpolation.has_native_binding", return_value=True
+        ):
+            from modules.rife_interpolation import has_native_binding, interpolate_frame_pair
+
+            # Simulate skip-frame logic
+            temp_frame = raw_frame.copy()
+            if has_native_binding():
+                intermediates = interpolate_frame_pair(prev_processed, temp_frame, multiplier=2)
+                if intermediates:
+                    temp_frame = intermediates[0]
+
+        assert mock_interp.call_count == 1
+        call_args, call_kwargs = mock_interp.call_args
+        assert np.array_equal(call_args[0], prev_processed)
+        assert np.array_equal(call_args[1], raw_frame)
+        assert call_kwargs.get("multiplier") == 2
+
+    def test_no_rife_call_without_prev_frame(self):
+        """No interpolation attempt when prev_processed_frame is None."""
+        prev_processed_frame = None
+        raw_frame = self._make_frame(100)
+
+        with patch("modules.rife_interpolation.interpolate_frame_pair") as mock_interp:
+            # Simulate skip-frame guard
+            if prev_processed_frame is not None:
+                from modules.rife_interpolation import interpolate_frame_pair
+                interpolate_frame_pair(prev_processed_frame, raw_frame, multiplier=2)
+
+        mock_interp.assert_not_called()
+
+    def test_raw_frame_kept_when_rife_returns_empty(self):
+        """When RIFE returns [], raw temp_frame is used unchanged."""
+        prev_processed = self._make_frame(50)
+        raw_frame = self._make_frame(100)
+        temp_frame = raw_frame.copy()
+
+        with patch(
+            "modules.rife_interpolation.interpolate_frame_pair", return_value=[]
+        ), patch("modules.rife_interpolation.has_native_binding", return_value=True):
+            from modules.rife_interpolation import has_native_binding, interpolate_frame_pair
+
+            if has_native_binding():
+                intermediates = interpolate_frame_pair(prev_processed, temp_frame, multiplier=2)
+                if intermediates:
+                    temp_frame = intermediates[0]
+
+        assert np.array_equal(temp_frame, raw_frame)
+
+
+# ---------------------------------------------------------------------------
+# prev_processed_frame lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestPrevFrameLifecycle:
+    """prev_processed_frame updated on keyframes only; unchanged on skip frames."""
+
+    def test_prev_frame_updated_on_keyframe(self):
+        prev_processed_frame = None
+        keyframe_result = np.ones((480, 640, 3), dtype=np.uint8) * 128
+
+        skip_face_processing = False  # keyframe
+        rife_enabled = True
+        half_rate_enabled = True
+        temp_frame = keyframe_result.copy()
+
+        if not skip_face_processing:
+            if rife_enabled or half_rate_enabled:
+                prev_processed_frame = temp_frame.copy()
+
+        assert prev_processed_frame is not None
+        assert np.array_equal(prev_processed_frame, keyframe_result)
+
+    def test_prev_frame_unchanged_on_skip_frame(self):
+        original = np.ones((480, 640, 3), dtype=np.uint8) * 128
+        prev_processed_frame = original.copy()
+
+        skip_face_processing = True  # skip frame
+        rife_enabled = True
+        half_rate_enabled = True
+
+        if not skip_face_processing:
+            # This branch would overwrite prev_processed_frame
+            prev_processed_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+
+        assert np.array_equal(prev_processed_frame, original)
+
+    def test_prev_frame_set_to_none_when_neither_enabled(self):
+        prev_processed_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        skip_face_processing = False
+        rife_enabled = False
+        half_rate_enabled = False
+
+        if not skip_face_processing:
+            if rife_enabled or half_rate_enabled:
+                prev_processed_frame = prev_processed_frame.copy()
+            else:
+                prev_processed_frame = None
+
+        assert prev_processed_frame is None
+
+
+# ---------------------------------------------------------------------------
+# Normal RIFE extra-frame emission suppressed on skip frames
+# ---------------------------------------------------------------------------
+
+
+class TestNormalRifeSuppressedOnSkipFrames:
+    """Normal RIFE extra-frame emission must not run on half-rate skip frames."""
+
+    def test_rife_block_skipped_when_skip_processing(self):
+        skip_face_processing = True
+        rife_enabled = True
+        prev_processed_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        frames_emitted = []
+
+        if rife_enabled and prev_processed_frame is not None and not skip_face_processing:
+            frames_emitted.append("extra_frame")
+
+        assert len(frames_emitted) == 0
+
+    def test_rife_block_runs_on_keyframes(self):
+        skip_face_processing = False  # keyframe
+        rife_enabled = True
+        prev_processed_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+        rife_ran = False
+
+        if rife_enabled and prev_processed_frame is not None and not skip_face_processing:
+            rife_ran = True
+
+        assert rife_ran is True
+
+
+# ---------------------------------------------------------------------------
+# Toggle on/off mid-stream
+# ---------------------------------------------------------------------------
+
+
+class TestToggleMidStream:
+    """Toggling half-rate on/off during live session must not crash or corrupt state."""
+
+    def test_frame_counter_logic_survives_toggle(self):
+        """Frame counter correctly classifies frames before and after toggle."""
+        keyframe_interval = 2
+        frame_counter = 0
+        skip_results = []
+
+        for i in range(1, 11):
+            frame_counter += 1
+            # Toggle half-rate on after frame 5
+            half_rate_enabled = i > 5
+            is_keyframe = (frame_counter % keyframe_interval) == 1
+            skip_face_processing = half_rate_enabled and not is_keyframe
+            skip_results.append(skip_face_processing)
+
+        # Frames 1-5: half-rate disabled → never skip
+        assert all(r is False for r in skip_results[:5])
+
+        # Frames 6-10: half-rate enabled; counter 6-10 alternates skip/keyframe
+        # frame 6: counter=6, 6%2=0, not keyframe → skip
+        # frame 7: counter=7, 7%2=1, keyframe → no skip
+        # frame 8: counter=8, 8%2=0, not keyframe → skip
+        # frame 9: counter=9, 9%2=1, keyframe → no skip
+        # frame 10: counter=10, 10%2=0, not keyframe → skip
+        assert skip_results[5] is True
+        assert skip_results[6] is False
+        assert skip_results[7] is True
+        assert skip_results[8] is False
+        assert skip_results[9] is True


### PR DESCRIPTION
## Summary

- Run face swap/enhancement only on every Nth camera frame (keyframes), skipping in-between frames
- Use RIFE to interpolate skip frames from the last keyframe output + current raw frame
- Output frame rate stays at camera FPS; face-processing GPU load drops by 1/N
- Normal RIFE extra-frame emission is suppressed on skip frames to avoid double-interpolation
- `prev_processed_frame` updated only on keyframes so skip-frame interpolation always anchors to the most recent fully-processed result

## Changes

| File | What changed |
|------|-------------|
| `modules/globals.py` | `half_rate_processing: bool`, `keyframe_interval: int` |
| `modules/core.py` | `--half-rate`, `--keyframe-interval N` CLI args |
| `modules/ui_webcam.py` | Frame counter + keyframe selection; skip-frame RIFE branch; correct `prev_processed_frame` lifecycle |
| `modules/ui.py` | "Half-Rate Processing" toggle in Live Mode tab; "Keyframe Interval" dropdown (2/3/4/5/8/10); persisted in `switch_states.json` |
| `tests/test_half_rate_processing.py` | 23 new tests (154 total, all passing) |

## Usage

```bash
# CLI — requires RIFE enabled
uv run run.py --rife --half-rate
uv run run.py --rife --half-rate --keyframe-interval 4

# GUI: Live Mode tab → Half-Rate Processing toggle + Keyframe Interval dropdown
```

## Test plan

- [ ] All 154 tests pass (`uv run pytest`)
- [ ] Live mode with `--rife --half-rate` at 30 fps camera → smooth output, ~50% GPU reduction
- [ ] `--keyframe-interval 4` → ~75% GPU reduction, verify no crash
- [ ] Toggle half-rate on/off mid-session via UI → no artifacts or crash
- [ ] Enable half-rate without RIFE → `[DLC.HALF-RATE]` warning printed once, raw frames used
- [ ] FPS overlay shows output rate (not input rate) when half-rate active

## Known trade-offs

- **Option A interpolation**: skip frames interpolate between last processed and current *raw* frame; may show minor boundary artifacts on fast head turns
- Adds one frame of latency on skip frames (~33 ms at 30 fps) — acceptable for video calls
- Future: Option B (keyframe-to-keyframe) for better quality at the cost of added latency

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)