### PR TITLE
fix(half-rate): hold last processed frame on skips to eliminate face-flicker

### DIFF
--- a/modules/ui_webcam.py
+++ b/modules/ui_webcam.py
@@ -176,24 +176,17 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
                     else:
                         temp_frame = frame_processor.process_frame(None, temp_frame)
         else:
-            # Skip frame: use RIFE to interpolate between the last keyframe and current raw frame
-            rife_for_skip = getattr(modules.globals, "rife_enabled", False)
-            if half_rate_enabled and not rife_for_skip:
-                if not half_rate_warned:
-                    print("[DLC.HALF-RATE] Half-rate processing requires RIFE — output will use raw frames on skips")
-                    half_rate_warned = True
-            elif rife_for_skip and prev_processed_frame is not None:
-                if not has_native_binding():
-                    if not half_rate_warned:
-                        print("[DLC.HALF-RATE] RIFE native binding not available — skip frames will use raw camera input")
-                        half_rate_warned = True
-                else:
-                    intermediates = interpolate_frame_pair(prev_processed_frame, temp_frame, multiplier=2)
-                    if intermediates:
-                        temp_frame = intermediates[0]
+            # Skip frame: hold the last processed frame to avoid blending swapped/raw content.
+            # Interpolating against a raw (unswapped) frame produces visible face-flicker artifacts.
+            # When RIFE is enabled, the normal RIFE section below will generate smooth intermediates
+            # between consecutive keyframes as they arrive (keyframe N → keyframe N+interval).
+            if prev_processed_frame is not None:
+                temp_frame = prev_processed_frame
 
         # RIFE frame interpolation: emit intermediate frames between consecutive keyframes.
-        # Suppressed on half-rate skip frames (those are handled in the else-branch above).
+        # In half-rate mode this fires on keyframes, bridging the gap since the previous keyframe
+        # (which may be keyframe_interval camera frames back). Skip frames are held above and
+        # never reach this block.
         rife_enabled = getattr(modules.globals, "rife_enabled", False)
         if rife_enabled and prev_processed_frame is not None and not skip_face_processing:
             if not rife_warned and not has_native_binding():

--- a/tests/test_half_rate_processing.py
+++ b/tests/test_half_rate_processing.py
@@ -108,56 +108,18 @@ class TestKeyframeLogic:
 
 
 # ---------------------------------------------------------------------------
-# Warning when RIFE unavailable
+# Skip-frame frame-hold behaviour
 # ---------------------------------------------------------------------------
 
 
-class TestHalfRateRifeRequirement:
-    """Half-rate mode should warn when RIFE is unavailable, not crash."""
+class TestSkipFrameHold:
+    """Skip frames must output the last processed frame, not raw camera input.
 
-    def test_warning_printed_when_rife_disabled(self, capsys):
-        """When half-rate=on and rife_enabled=False, a warning is logged on skip frames."""
-        half_rate_enabled = True
-        rife_enabled = False
-        half_rate_warned = False
-        frame_counter = 2        # skip frame for interval=2
-        keyframe_interval = 2
-        is_keyframe = (frame_counter % keyframe_interval) == 1
-        skip_face_processing = half_rate_enabled and not is_keyframe
-
-        # Replicate warning logic from _processing_thread_func else-branch
-        if skip_face_processing and half_rate_enabled and not rife_enabled:
-            if not half_rate_warned:
-                print(
-                    "[DLC.HALF-RATE] Half-rate processing requires RIFE "
-                    "— output will use raw frames on skips"
-                )
-                half_rate_warned = True
-
-        captured = capsys.readouterr()
-        assert "[DLC.HALF-RATE]" in captured.out
-        assert half_rate_warned is True
-
-    def test_warning_fires_only_once(self):
-        """The half_rate_warned flag prevents repeated warning prints."""
-        half_rate_warned = False
-        warning_count = 0
-
-        for _ in range(5):  # simulate 5 consecutive skip frames
-            if not half_rate_warned:
-                warning_count += 1
-                half_rate_warned = True
-
-        assert warning_count == 1
-
-
-# ---------------------------------------------------------------------------
-# RIFE interpolation on skip frames
-# ---------------------------------------------------------------------------
-
-
-class TestSkipFrameRifeInterpolation:
-    """Verify RIFE is called with (prev_processed, current_raw) on skip frames."""
+    Interpolating a swapped keyframe against a raw (unswapped) frame produces
+    visible face-flicker artifacts.  The correct behaviour is to hold the last
+    processed frame on skips; RIFE interpolation between consecutive keyframes
+    is handled by the normal RIFE section when the next keyframe arrives.
+    """
 
     @staticmethod
     def _make_frame(fill: int = 0) -> np.ndarray:
@@ -165,63 +127,41 @@ class TestSkipFrameRifeInterpolation:
         frame[:] = fill
         return frame
 
-    def test_rife_called_with_prev_processed_and_raw(self):
-        """interpolate_frame_pair receives (prev_processed_frame, raw_temp_frame)."""
-        prev_processed = self._make_frame(50)
-        raw_frame = self._make_frame(100)
-        interp_frame = self._make_frame(75)
+    def test_skip_frame_outputs_prev_processed(self):
+        """On a skip frame, temp_frame becomes prev_processed_frame (frame hold)."""
+        prev_processed = self._make_frame(50)   # last swapped keyframe
+        raw_frame = self._make_frame(100)        # current unswapped camera frame
+        temp_frame = raw_frame.copy()
 
-        with patch(
-            "modules.rife_interpolation.interpolate_frame_pair",
-            return_value=[interp_frame],
-        ) as mock_interp, patch(
-            "modules.rife_interpolation.has_native_binding", return_value=True
-        ):
-            from modules.rife_interpolation import has_native_binding, interpolate_frame_pair
+        # Simulate skip-frame logic from _processing_thread_func
+        if prev_processed is not None:
+            temp_frame = prev_processed
 
-            # Simulate skip-frame logic
-            temp_frame = raw_frame.copy()
-            if has_native_binding():
-                intermediates = interpolate_frame_pair(prev_processed, temp_frame, multiplier=2)
-                if intermediates:
-                    temp_frame = intermediates[0]
+        assert np.array_equal(temp_frame, prev_processed)
+        assert not np.array_equal(temp_frame, raw_frame)
 
-        assert mock_interp.call_count == 1
-        call_args, call_kwargs = mock_interp.call_args
-        assert np.array_equal(call_args[0], prev_processed)
-        assert np.array_equal(call_args[1], raw_frame)
-        assert call_kwargs.get("multiplier") == 2
-
-    def test_no_rife_call_without_prev_frame(self):
-        """No interpolation attempt when prev_processed_frame is None."""
+    def test_skip_frame_keeps_raw_when_no_prev(self):
+        """When no prev_processed_frame exists yet, raw frame is used as-is."""
         prev_processed_frame = None
-        raw_frame = self._make_frame(100)
-
-        with patch("modules.rife_interpolation.interpolate_frame_pair") as mock_interp:
-            # Simulate skip-frame guard
-            if prev_processed_frame is not None:
-                from modules.rife_interpolation import interpolate_frame_pair
-                interpolate_frame_pair(prev_processed_frame, raw_frame, multiplier=2)
-
-        mock_interp.assert_not_called()
-
-    def test_raw_frame_kept_when_rife_returns_empty(self):
-        """When RIFE returns [], raw temp_frame is used unchanged."""
-        prev_processed = self._make_frame(50)
         raw_frame = self._make_frame(100)
         temp_frame = raw_frame.copy()
 
-        with patch(
-            "modules.rife_interpolation.interpolate_frame_pair", return_value=[]
-        ), patch("modules.rife_interpolation.has_native_binding", return_value=True):
-            from modules.rife_interpolation import has_native_binding, interpolate_frame_pair
-
-            if has_native_binding():
-                intermediates = interpolate_frame_pair(prev_processed, temp_frame, multiplier=2)
-                if intermediates:
-                    temp_frame = intermediates[0]
+        if prev_processed_frame is not None:
+            temp_frame = prev_processed_frame
 
         assert np.array_equal(temp_frame, raw_frame)
+
+    def test_rife_not_called_on_skip_frame(self):
+        """interpolate_frame_pair is never called during a skip frame."""
+        with patch("modules.rife_interpolation.interpolate_frame_pair") as mock_interp:
+            # Simulate the new skip-frame branch: just hold prev frame, no RIFE
+            prev_processed = self._make_frame(50)
+            temp_frame = self._make_frame(100)
+            if prev_processed is not None:
+                temp_frame = prev_processed
+            # RIFE is NOT called here
+
+        mock_interp.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes the skip-frame RIFE interpolation branch introduced in #31
- On skip frames, `temp_frame` is now set to `prev_processed_frame` (frame hold)
- The normal RIFE section already bridges consecutive keyframes when the next keyframe arrives — no separate per-skip RIFE call is needed

## Root cause

The original implementation called `interpolate_frame_pair(prev_processed_frame, raw_frame)` on skip frames. This blended a fully face-swapped keyframe with an unswapped raw camera frame at timestep 0.5, producing a 50/50 mix of the two faces on every skip frame — visible as the face flashing between swapped and unswapped on alternating frames.

## Fix

Skip frames output `prev_processed_frame` directly (frame hold). The output is always fully face-swapped; fast head movement may show a brief hold, but there are no blend artifacts.

## Test plan

- [ ] Enable half-rate + RIFE in live mode — face stays consistently swapped, no flicker
- [ ] All 152 tests pass (`uv run pytest`)
- [ ] Toggle half-rate on/off mid-session — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)