### PR TITLE
docs: simplify README and auto-generate CLI args table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Deep-Live-Cam 2.0.5c</h1>
+<h1 align="center">Deep-Live-Cam</h1>
 
 <p align="center">
   Real-time face swap and video deepfake with a single click and only a single image.
@@ -12,39 +12,28 @@
   <img src="media/demo.gif" alt="Demo GIF" width="800">
 </p>
 
-##  Disclaimer
+## Disclaimer
 
 This deepfake software is designed to be a productive tool for the AI-generated media industry. It can assist artists in animating custom characters, creating engaging content, and even using models for clothing design.
 
 We are aware of the potential for unethical applications and are committed to preventative measures. A built-in check prevents the program from processing inappropriate media (nudity, graphic content, sensitive material like war footage, etc.). We will continue to develop this project responsibly, adhering to the law and ethics. We may shut down the project or add watermarks if legally required.
 
-- Ethical Use: Users are expected to use this software responsibly and legally. If using a real person's face, obtain their consent and clearly label any output as a deepfake when sharing online.
-
-- Content Restrictions: The software includes built-in checks to prevent processing inappropriate media, such as nudity, graphic content, or sensitive material.
-
-- Legal Compliance: We adhere to all relevant laws and ethical guidelines. If legally required, we may shut down the project or add watermarks to the output.
-
-- User Responsibility: We are not responsible for end-user actions. Users must ensure their use of the software aligns with ethical standards and legal requirements.
+- **Ethical Use**: Users are expected to use this software responsibly and legally. If using a real person's face, obtain their consent and clearly label any output as a deepfake when sharing online.
+- **Content Restrictions**: The software includes built-in checks to prevent processing inappropriate media, such as nudity, graphic content, or sensitive material.
+- **Legal Compliance**: We adhere to all relevant laws and ethical guidelines. If legally required, we may shut down the project or add watermarks to the output.
+- **User Responsibility**: We are not responsible for end-user actions. Users must ensure their use of the software aligns with ethical standards and legal requirements.
 
 By using this software, you agree to these terms and commit to using it in a manner that respects the rights and dignity of others.
 
-Users are expected to use this software responsibly and legally. If using a real person's face, obtain their consent and clearly label any output as a deepfake when sharing online. We are not responsible for end-user actions.
+## Quick Demo
 
-## Exclusive v2.6d Quick Start - Pre-built (Windows/Mac Silicon)
-
-  <a href="https://deeplivecam.net/index.php/quickstart"> <img src="media/Download.png" width="285" height="77" />
-
-##### This is the fastest build you can get if you have a discrete NVIDIA or AMD GPU or Mac Silicon, And you'll receive special priority support.
- 
-###### These Pre-builts are perfect for non-technical users or those who don't have time to, or can't manually install all the requirements. Just a heads-up: this is an open-source project, so you can also install it manually. 
-
-## TLDR; Live Deepfake in just 3 Clicks
 ![easysteps](https://github.com/user-attachments/assets/af825228-852c-411b-b787-ffd9aac72fc6)
+
 1. Select a face
 2. Select which camera to use
 3. Press live!
 
-## Features & Uses - Everything is in real-time
+## Features
 
 ### Mouth Mask
 
@@ -83,307 +72,149 @@ Users are expected to use this software responsibly and legally. If using a real
 **Create Your Most Viral Meme Yet**
 
 <p align="center">
-  <img src="media/meme.gif" alt="show" width="450"> 
+  <img src="media/meme.gif" alt="show" width="450">
   <br>
   <sub>Created using Many Faces feature in Deep-Live-Cam</sub>
 </p>
 
-### Omegle
+## Installation
 
-**Surprise people on Omegle**
+### Prerequisites
 
-<p align="center">
-  <video src="https://github.com/user-attachments/assets/2e9b9b82-fa04-4b70-9f56-b1f68e7672d0" width="450" controls></video>
-</p>
+- **Python 3.10** (managed via [mise](https://mise.jdx.dev/) or installed manually)
+- **ffmpeg** on PATH
+- **git**
 
-## Installation (Manual)
-
-**Please be aware that the installation requires technical skills and is not for beginners. Consider downloading the quickstart version.**
-
-<details>
-<summary>Click to see the process</summary>
-
-### Installation
-
-This is more likely to work on your computer but will be slower as it utilizes the CPU.
-
-**1. Set up Your Platform**
-
--   Python (3.11 recommended)
--   pip
--   git
--   [ffmpeg](https://www.youtube.com/watch?v=OlNWCpFdVMA) - ```iex (irm ffmpeg.tc.ht)```
--   [Visual Studio 2022 Runtimes (Windows)](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
-
-**2. Clone the Repository**
+### Setup
 
 ```bash
 git clone https://github.com/hacksider/Deep-Live-Cam.git
 cd Deep-Live-Cam
+just setup    # installs dependencies (uv sync) + downloads models
 ```
 
-**3. Download the Models**
+> If you don't have `just`, install it via `brew install just`, `cargo install just`, or see [just installation](https://github.com/casey/just#installation). Alternatively, run `uv sync` and download models manually into `models/`.
 
-1. [GFPGANv1.4](https://huggingface.co/hacksider/deep-live-cam/resolve/main/GFPGANv1.4.onnx)
-2. [inswapper\_128\_fp16.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx)
+### GPU Providers
 
-Place these files in the "**models**" folder.
+| Platform | Provider | How to run |
+|----------|----------|------------|
+| macOS ARM (M1/M2/M3/M4) | CoreML | `just start` (auto-detected) |
+| NVIDIA | CUDA | `just start` (auto-detected) |
+| AMD | ROCm | `just start-with rocm` |
+| Intel | OpenVINO | `just start-with openvino` |
+| Windows (any GPU) | DirectML | `just start-with directml` |
+| CPU only | - | `just start-cpu` |
 
-**4. Install Dependencies**
-
-We highly recommend using a `venv` to avoid issues.
-
-
-For Windows:
-```bash
-python -m venv venv
-venv\Scripts\activate
-pip install -r requirements.txt
-```
-For Linux:
-```bash
-# Ensure you use the installed Python 3.10
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-```
-
-**For macOS:**
-
-Apple Silicon (M1/M2/M3) requires specific setup:
-
-```bash
-# Install Python 3.11 (specific version is important)
-brew install python@3.11
-
-# Install tkinter package (required for the GUI)
-brew install python-tk@3.10
-
-# Create and activate virtual environment with Python 3.11
-python3.11 -m venv venv
-source venv/bin/activate
-
-# Install dependencies
-pip install -r requirements.txt
-```
-
-** In case something goes wrong and you need to reinstall the virtual environment **
-
-```bash
-# Deactivate the virtual environment
-rm -rf venv
-
-# Reinstall the virtual environment
-python -m venv venv
-source venv/bin/activate
-
-# install the dependencies again
-pip install -r requirements.txt
-
-# gfpgan and basicsrs issue fix
-pip install git+https://github.com/xinntao/BasicSR.git@master
-pip uninstall gfpgan -y
-pip install git+https://github.com/TencentARC/GFPGAN.git@master
-```
-
-**Run:** If you don't have a GPU, you can run Deep-Live-Cam using `python run.py`. Note that initial execution will download models (~300MB).
-
-### GPU Acceleration
-
-**CUDA Execution Provider (Nvidia)**
-
-1. Install [CUDA Toolkit 12.8.0](https://developer.nvidia.com/cuda-12-8-0-download-archive)
-2. Install [cuDNN v8.9.7 for CUDA 12.x](https://developer.nvidia.com/rdp/cudnn-archive) (required for onnxruntime-gpu):
-   - Download cuDNN v8.9.7 for CUDA 12.x
-   - Make sure the cuDNN bin directory is in your system PATH
-3. Install dependencies:
-
-```bash
-pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
-pip uninstall onnxruntime onnxruntime-gpu
-pip install onnxruntime-gpu==1.21.0
-```
-
-3. Usage:
-
-```bash
-python run.py --execution-provider cuda
-```
-
-**CoreML Execution Provider (Apple Silicon)**
-
-Apple Silicon (M1/M2/M3) specific installation:
-
-1. Make sure you've completed the macOS setup above using Python 3.10.
-2. Install dependencies:
-
-```bash
-pip uninstall onnxruntime onnxruntime-silicon
-pip install onnxruntime-silicon==1.13.1
-```
-
-3. Usage (important: specify Python 3.10):
-
-```bash
-python3.10 run.py --execution-provider coreml
-```
-
-**Important Notes for macOS:**
-- You **must** use Python 3.10, not newer versions like 3.11 or 3.13
-- Always run with `python3.10` command not just `python` if you have multiple Python versions installed
-- If you get error about `_tkinter` missing, reinstall the tkinter package: `brew reinstall python-tk@3.10`
-- If you get model loading errors, check that your models are in the correct folder
-- If you encounter conflicts with other Python versions, consider uninstalling them:
-  ```bash
-  # List all installed Python versions
-  brew list | grep python
-  
-  # Uninstall conflicting versions if needed
-  brew uninstall --ignore-dependencies python@3.11 python@3.13
-  
-  # Keep only Python 3.11
-  brew cleanup
-  ```
-
-**CoreML Execution Provider (Apple Legacy)**
-
-1. Install dependencies:
-
-```bash
-pip uninstall onnxruntime onnxruntime-coreml
-pip install onnxruntime-coreml==1.21.0
-```
-
-2. Usage:
-
-```bash
-python run.py --execution-provider coreml
-```
-
-**DirectML Execution Provider (Windows)**
-
-1. Install dependencies:
-
-```bash
-pip uninstall onnxruntime onnxruntime-directml
-pip install onnxruntime-directml==1.21.0
-```
-
-2. Usage:
-
-```bash
-python run.py --execution-provider directml
-```
-
-**OpenVINO™ Execution Provider (Intel)**
-
-1. Install dependencies:
-
-```bash
-pip uninstall onnxruntime onnxruntime-openvino
-pip install onnxruntime-openvino==1.21.0
-```
-
-2. Usage:
-
-```bash
-python run.py --execution-provider openvino
-```
-</details>
+GPU-specific ONNX runtimes are handled automatically by `pyproject.toml` platform markers. For CUDA, ensure [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit) and [cuDNN](https://developer.nvidia.com/cudnn) are installed.
 
 ## Usage
 
-**1. Image/Video Mode**
+### GUI (Live Webcam)
 
--   Execute `python run.py`.
--   Choose a source face image and a target image/video.
--   Click "Start".
--   The output will be saved in a directory named after the target video.
-
-**2. Webcam Mode**
-
--   Execute `python run.py`.
--   Select a source face image.
--   Click "Live".
--   Wait for the preview to appear (10-30 seconds).
--   Use a screen capture tool like OBS to stream, or enable the Virtual Camera toggle (see below).
--   To change the face, select a new source image.
-
-**3. Virtual Camera Mode**
-
-Send the face-swapped output directly to a virtual camera device that Zoom, Google Meet, Discord, and other apps can select — no OBS screen capture needed.
-
--   **Setup (one-time)**:
-    -   macOS: Install OBS 30+, open it, click Start Virtual Camera, then Stop, then close OBS.
-    -   Linux: `sudo apt install v4l2loopback-dkms && sudo modprobe v4l2loopback devices=1`
-    -   Windows: Install OBS 26+.
--   **Usage**: Enable the "Virtual Camera" toggle in the Live Mode settings tab, then start Live preview. In your video call app, select "OBS Virtual Camera" as the camera input.
--   **CLI**: `python run.py --virtual-cam --execution-provider coreml`
-
-## Command Line Arguments (Unmaintained)
-
-```
-options:
-  -h, --help                                               show this help message and exit
-  -s SOURCE_PATH, --source SOURCE_PATH                     select a source image
-  -t TARGET_PATH, --target TARGET_PATH                     select a target image or video
-  -o OUTPUT_PATH, --output OUTPUT_PATH                     select output file or directory
-  --frame-processor FRAME_PROCESSOR [FRAME_PROCESSOR ...]  frame processors (choices: face_swapper, face_enhancer, ...)
-  --keep-fps                                               keep original fps
-  --keep-audio                                             keep original audio
-  --keep-frames                                            keep temporary frames
-  --many-faces                                             process every face
-  --map-faces                                              map source target faces
-  --mouth-mask                                             mask the mouth region
-  --video-encoder {libx264,libx265,libvpx-vp9}             adjust output video encoder
-  --video-quality [0-51]                                   adjust output video quality
-  --live-mirror                                            the live camera display as you see it in the front-facing camera frame
-  --live-resizable                                         the live camera frame is resizable
-  --virtual-cam                                            output to virtual camera device
-  --max-memory MAX_MEMORY                                  maximum amount of RAM in GB
-  --execution-provider {cpu} [{cpu} ...]                   available execution provider (choices: cpu, ...)
-  --execution-threads EXECUTION_THREADS                    number of execution threads
-  -v, --version                                            show program's version number and exit
+```bash
+just start              # launch GUI with platform-default GPU
 ```
 
-Looking for a CLI mode? Using the -s/--source argument will make the run program in cli mode.
+Select a source face image, choose your camera, and click **Live**.
+
+### Headless (Image/Video)
+
+```bash
+uv run run.py -s source.jpg -t target.mp4 -o output.mp4
+uv run run.py -s source.jpg -t target.jpg -o output.jpg --frame-processor face_swapper face_enhancer
+```
+
+### Virtual Camera
+
+Send processed output directly to Zoom, Google Meet, Discord — no screen capture needed.
+
+```bash
+just start-virtualcam
+```
+
+**One-time setup**: macOS — install OBS 30+, start/stop virtual camera once. Linux — `sudo apt install v4l2loopback-dkms && sudo modprobe v4l2loopback devices=1`. Windows — install OBS 26+.
+
+## Command Line Arguments
+
+<!-- CLI_ARGS_START -->
+*Deep-Live-Cam v2.0.3c* — run `uv run run.py --help` for latest options.
+
+| Flag | Description | Default | Choices |
+|------|-------------|---------|---------|
+| `-s, --source` | select an source image |  |  |
+| `-t, --target` | select an target image or video |  |  |
+| `-o, --output` | select output file or directory |  |  |
+| `--frame-processor` | pipeline of frame processors | `'face_swapper'` | `'face_swapper', 'face_enhancer', 'face_enhancer_gpen256', 'face_enhancer_gpen512'` |
+| `--keep-fps` | keep original fps | `False` |  |
+| `--keep-audio` | keep original audio | `True` |  |
+| `--keep-frames` | keep temporary frames | `False` |  |
+| `--many-faces` | process every face | `False` |  |
+| `--nsfw-filter` | filter the NSFW image or video | `False` |  |
+| `--map-faces` | map source target faces | `False` |  |
+| `--mouth-mask` | mask the mouth region | `False` |  |
+| `--video-encoder` | adjust output video encoder | `'libx264'` | `'libx264', 'libx265', 'libvpx-vp9'` |
+| `--video-quality` | adjust output video quality | `18` | `0-51` |
+| `-l, --lang` | Ui language | `'en'` |  |
+| `--live-mirror` | The live camera display as you see it in the front-facing camera frame | `False` |  |
+| `--live-resizable` | The live camera frame is resizable | `False` |  |
+| `--virtual-cam` | output to virtual camera device | `False` |  |
+| `--rife` | enable RIFE frame interpolation for video output | `False` |  |
+| `--rife-model` | RIFE model to use | `'rife-v4.25-lite'` | `'rife-v4.25', 'rife-v4.25-lite'` |
+| `--rife-multiplier` | RIFE frame rate multiplier (2=double, 4=quadruple) | `2` | `2, 4` |
+| `--half-rate` | enable half-rate face processing with RIFE interpolation for live mode | `False` |  |
+| `--keyframe-interval` | process every Nth frame in half-rate mode (2-10) | `2` | `2-10` |
+| `--max-memory` | maximum amount of RAM in GB | `(auto)` |  |
+| `--execution-provider` | execution provider | `'cpu'` | `(auto)` |
+| `--execution-threads` | number of execution threads | `(auto)` |  |
+<!-- CLI_ARGS_END -->
+
+Using `-s`/`--source` triggers headless (CLI) mode — no GUI window opens.
+
+## Development
+
+```bash
+just --list             # see all available recipes
+just test-quick         # fast unit tests
+just test               # full test suite
+just test-cov           # tests with coverage report
+```
+
+See [CLAUDE.md](CLAUDE.md) for full developer documentation.
 
 ## Press
 
-**We are always open to criticism and are ready to improve, that's why we didn't cherry-pick anything.**
-
- - [*"Deep-Live-Cam goes viral, allowing anyone to become a digital doppelganger"*](https://arstechnica.com/information-technology/2024/08/new-ai-tool-enables-real-time-face-swapping-on-webcams-raising-fraud-concerns/) - Ars Technica
- - [*"Thanks Deep Live Cam, shapeshifters are among us now"*](https://dataconomy.com/2024/08/15/what-is-deep-live-cam-github-deepfake/) - Dataconomy
- - [*"This free AI tool lets you become anyone during video-calls"*](https://www.newsbytesapp.com/news/science/deep-live-cam-ai-impersonation-tool-goes-viral/story) - NewsBytes
- - [*"OK, this viral AI live stream software is truly terrifying"*](https://www.creativebloq.com/ai/ok-this-viral-ai-live-stream-software-is-truly-terrifying) - Creative Bloq
- - [*"Deepfake AI Tool Lets You Become Anyone in a Video Call With Single Photo"*](https://petapixel.com/2024/08/14/deep-live-cam-deepfake-ai-tool-lets-you-become-anyone-in-a-video-call-with-single-photo-mark-zuckerberg-jd-vance-elon-musk/) - PetaPixel
- - [*"Deep-Live-Cam Uses AI to Transform Your Face in Real-Time, Celebrities Included"*](https://www.techeblog.com/deep-live-cam-ai-transform-face/) - TechEBlog
- - [*"An AI tool that "makes you look like anyone" during a video call is going viral online"*](https://telegrafi.com/en/a-tool-that-makes-you-look-like-anyone-during-a-video-call-is-going-viral-on-the-Internet/) - Telegrafi
- - [*"This Deepfake Tool Turning Images Into Livestreams is Topping the GitHub Charts"*](https://decrypt.co/244565/this-deepfake-tool-turning-images-into-livestreams-is-topping-the-github-charts) - Emerge
- - [*"New Real-Time Face-Swapping AI Allows Anyone to Mimic Famous Faces"*](https://www.digitalmusicnews.com/2024/08/15/face-swapping-ai-real-time-mimic/) - Digital Music News
- - [*"This real-time webcam deepfake tool raises alarms about the future of identity theft"*](https://www.diyphotography.net/this-real-time-webcam-deepfake-tool-raises-alarms-about-the-future-of-identity-theft/) - DIYPhotography
- - [*"That's Crazy, Oh God. That's Fucking Freaky Dude... That's So Wild Dude"*](https://www.youtube.com/watch?time_continue=1074&v=py4Tc-Y8BcY) - SomeOrdinaryGamers
- - [*"Alright look look look, now look chat, we can do any face we want to look like chat"*](https://www.youtube.com/live/mFsCe7AIxq8?feature=shared&t=2686) - IShowSpeed
- - [*"They do a pretty good job matching poses, expression and even the lighting"*](https://www.youtube.com/watch?v=wnCghLjqv3s&t=551s) - TechLinked (LTT)
- - [*"Als Sean Connery an der Redaktionskonferenz teilnahm"*](https://www.golem.de/news/deepfakes-als-sean-connery-an-der-redaktionskonferenz-teilnahm-2408-188172.html) - Golem.de (German)
- - [*"What the F***! Why do I look like Vinny Jr? I look exactly like Vinny Jr!? No, this shit is crazy! Bro This is F*** Crazy! "*](https://youtu.be/JbUPRmXRUtE?t=3964) - IShowSpeed
-
+- [*"Deep-Live-Cam goes viral, allowing anyone to become a digital doppelganger"*](https://arstechnica.com/information-technology/2024/08/new-ai-tool-enables-real-time-face-swapping-on-webcams-raising-fraud-concerns/) - Ars Technica
+- [*"Thanks Deep Live Cam, shapeshifters are among us now"*](https://dataconomy.com/2024/08/15/what-is-deep-live-cam-github-deepfake/) - Dataconomy
+- [*"This free AI tool lets you become anyone during video-calls"*](https://www.newsbytesapp.com/news/science/deep-live-cam-ai-impersonation-tool-goes-viral/story) - NewsBytes
+- [*"OK, this viral AI live stream software is truly terrifying"*](https://www.creativebloq.com/ai/ok-this-viral-ai-live-stream-software-is-truly-terrifying) - Creative Bloq
+- [*"Deepfake AI Tool Lets You Become Anyone in a Video Call With Single Photo"*](https://petapixel.com/2024/08/14/deep-live-cam-deepfake-ai-tool-lets-you-become-anyone-in-a-video-call-with-single-photo-mark-zuckerberg-jd-vance-elon-musk/) - PetaPixel
+- [*"Deep-Live-Cam Uses AI to Transform Your Face in Real-Time, Celebrities Included"*](https://www.techeblog.com/deep-live-cam-ai-transform-face/) - TechEBlog
+- [*"An AI tool that "makes you look like anyone" during a video call is going viral online"*](https://telegrafi.com/en/a-tool-that-makes-you-look-like-anyone-during-a-video-call-is-going-viral-on-the-Internet/) - Telegrafi
+- [*"This Deepfake Tool Turning Images Into Livestreams is Topping the GitHub Charts"*](https://decrypt.co/244565/this-deepfake-tool-turning-images-into-livestreams-is-topping-the-github-charts) - Emerge
+- [*"New Real-Time Face-Swapping AI Allows Anyone to Mimic Famous Faces"*](https://www.digitalmusicnews.com/2024/08/15/face-swapping-ai-real-time-mimic/) - Digital Music News
+- [*"This real-time webcam deepfake tool raises alarms about the future of identity theft"*](https://www.diyphotography.net/this-real-time-webcam-deepfake-tool-raises-alarms-about-the-future-of-identity-theft/) - DIYPhotography
+- [*"That's Crazy, Oh God. That's Fucking Freaky Dude... That's So Wild Dude"*](https://www.youtube.com/watch?time_continue=1074&v=py4Tc-Y8BcY) - SomeOrdinaryGamers
+- [*"Alright look look look, now look chat, we can do any face we want to look like chat"*](https://www.youtube.com/live/mFsCe7AIxq8?feature=shared&t=2686) - IShowSpeed
+- [*"They do a pretty good job matching poses, expression and even the lighting"*](https://www.youtube.com/watch?v=wnCghLjqv3s&t=551s) - TechLinked (LTT)
+- [*"Als Sean Connery an der Redaktionskonferenz teilnahm"*](https://www.golem.de/news/deepfakes-als-sean-connery-an-der-redaktionskonferenz-teilnahm-2408-188172.html) - Golem.de (German)
+- [*"What the F***! Why do I look like Vinny Jr? I look exactly like Vinny Jr!? No, this shit is crazy! Bro This is F*** Crazy! "*](https://youtu.be/JbUPRmXRUtE?t=3964) - IShowSpeed
 
 ## Credits
 
--   [ffmpeg](https://ffmpeg.org/): for making video-related operations easy
--   [Henry](https://github.com/henryruhs): One of the major contributor in this repo
--   [deepinsight](https://github.com/deepinsight): for their [insightface](https://github.com/deepinsight/insightface) project which provided a well-made library and models. Please be reminded that the [use of the model is for non-commercial research purposes only](https://github.com/deepinsight/insightface?tab=readme-ov-file#license).
--   [havok2-htwo](https://github.com/havok2-htwo): for sharing the code for webcam
--   [GosuDRM](https://github.com/GosuDRM): for the open version of roop
--   [pereiraroland26](https://github.com/pereiraroland26): Multiple faces support
--   [vic4key](https://github.com/vic4key): For supporting/contributing to this project
--   [kier007](https://github.com/kier007): for improving the user experience
--   [qitianai](https://github.com/qitianai): for multi-lingual support
--   [laurigates](https://github.com/laurigates): Decoupling stuffs to make everything faster!
--   and [all developers](https://github.com/hacksider/Deep-Live-Cam/graphs/contributors) behind libraries used in this project.
--   Footnote: Please be informed that the base author of the code is [s0md3v](https://github.com/s0md3v/roop)
--   All the wonderful users who helped make this project go viral by starring the repo ❤️
+- [ffmpeg](https://ffmpeg.org/): for making video-related operations easy
+- [Henry](https://github.com/henryruhs): One of the major contributor in this repo
+- [deepinsight](https://github.com/deepinsight): for their [insightface](https://github.com/deepinsight/insightface) project which provided a well-made library and models. Please be reminded that the [use of the model is for non-commercial research purposes only](https://github.com/deepinsight/insightface?tab=readme-ov-file#license).
+- [havok2-htwo](https://github.com/havok2-htwo): for sharing the code for webcam
+- [GosuDRM](https://github.com/GosuDRM): for the open version of roop
+- [pereiraroland26](https://github.com/pereiraroland26): Multiple faces support
+- [vic4key](https://github.com/vic4key): For supporting/contributing to this project
+- [kier007](https://github.com/kier007): for improving the user experience
+- [qitianai](https://github.com/qitianai): for multi-lingual support
+- [laurigates](https://github.com/laurigates): Decoupling stuffs to make everything faster!
+- and [all developers](https://github.com/hacksider/Deep-Live-Cam/graphs/contributors) behind libraries used in this project.
+- Footnote: Please be informed that the base author of the code is [s0md3v](https://github.com/s0md3v/roop)
+- All the wonderful users who helped make this project go viral by starring the repo
 
 [![Stargazers](https://reporoster.com/stars/hacksider/Deep-Live-Cam)](https://github.com/hacksider/Deep-Live-Cam/stargazers)
 
@@ -391,7 +222,7 @@ Looking for a CLI mode? Using the -s/--source argument will make the run program
 
 ![Alt](https://repobeats.axiom.co/api/embed/fec8e29c45dfdb9c5916f3a7830e1249308d20e1.svg "Repobeats analytics image")
 
-## Stars to the Moon 🚀
+## Stars
 
 <a href="https://star-history.com/#hacksider/deep-live-cam&Date">
  <picture>

--- a/justfile
+++ b/justfile
@@ -196,6 +196,16 @@ test-blas:
 # Maintenance
 ##########
 
+# Regenerate CLI args table in README.md from modules/core.py
+[group: "maintenance"]
+generate-cli-docs:
+    uv run scripts/generate_cli_docs.py
+
+# Check if README.md CLI args section is up to date (exits non-zero if stale)
+[group: "maintenance"]
+check-cli-docs:
+    uv run scripts/generate_cli_docs.py --check
+
 # Clean up virtual environment and lock file
 [group: "maintenance"]
 [confirm("Remove virtual environment?")]

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -1,0 +1,225 @@
+"""Generate CLI argument documentation from modules/core.py using AST parsing.
+
+Extracts all argparse add_argument() calls from parse_args(), skips deprecated
+args (help=argparse.SUPPRESS), and outputs a markdown table. Can update README.md
+in-place between marker comments or print to stdout.
+
+Usage:
+    uv run scripts/generate_cli_docs.py          # Update README.md in-place
+    uv run scripts/generate_cli_docs.py --check   # Exit non-zero if README is stale
+    uv run scripts/generate_cli_docs.py --stdout   # Print table to stdout
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+# Safe import — metadata.py contains only string literals
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from modules.metadata import name as app_name, version as app_version
+
+CORE_PY = Path(__file__).resolve().parent.parent / "modules" / "core.py"
+README_MD = Path(__file__).resolve().parent.parent / "README.md"
+START_MARKER = "<!-- CLI_ARGS_START -->"
+END_MARKER = "<!-- CLI_ARGS_END -->"
+
+
+def _resolve_constant(node: ast.expr) -> str:
+    """Resolve an AST node to a display string for defaults/choices."""
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+    if isinstance(node, ast.List):
+        items = [_resolve_constant(el) for el in node.elts]
+        return ", ".join(items)
+    # range(52) → "0-51", range(2, 11) → "2-10"
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "range":
+        args = node.args
+        if len(args) == 1:
+            stop = _resolve_constant(args[0])
+            return f"0-{int(stop) - 1}"
+        if len(args) >= 2:
+            start = _resolve_constant(args[0])
+            stop = _resolve_constant(args[1])
+            return f"{start}-{int(stop) - 1}"
+    # Function calls like suggest_max_memory() → "(auto)"
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        return "(auto)"
+    if isinstance(node, ast.Attribute):
+        # argparse.SUPPRESS
+        if isinstance(node.value, ast.Name) and node.attr == "SUPPRESS":
+            return "SUPPRESS"
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return f"-{_resolve_constant(node.operand)}"
+    return str(ast.dump(node))
+
+
+def extract_args(source: str) -> list[dict]:
+    """Parse source code and extract add_argument() calls from parse_args()."""
+    tree = ast.parse(source)
+
+    # Find parse_args function
+    parse_fn = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "parse_args":
+            parse_fn = node
+            break
+
+    if parse_fn is None:
+        raise ValueError("parse_args() function not found in source")
+
+    args_list = []
+    for node in ast.walk(parse_fn):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "add_argument":
+            continue
+
+        # Extract keyword arguments
+        kwargs = {}
+        for kw in node.keywords:
+            kwargs[kw.arg] = kw.value
+
+        # Skip deprecated args (help=argparse.SUPPRESS)
+        if "help" in kwargs:
+            help_val = _resolve_constant(kwargs["help"])
+            if help_val == "SUPPRESS":
+                continue
+
+        # Extract positional flag strings
+        flags = []
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                flags.append(arg.value)
+
+        if not flags:
+            continue
+
+        entry = {"flags": ", ".join(flags)}
+
+        # Help text
+        if "help" in kwargs and isinstance(kwargs["help"], ast.Constant):
+            entry["help"] = kwargs["help"].value
+        else:
+            entry["help"] = ""
+
+        # Default
+        if "default" in kwargs:
+            entry["default"] = _resolve_constant(kwargs["default"])
+        else:
+            entry["default"] = ""
+
+        # Choices
+        if "choices" in kwargs:
+            entry["choices"] = _resolve_constant(kwargs["choices"])
+        else:
+            entry["choices"] = ""
+
+        # Action (store_true, version, etc.)
+        if "action" in kwargs and isinstance(kwargs["action"], ast.Constant):
+            entry["action"] = kwargs["action"].value
+        else:
+            entry["action"] = ""
+
+        args_list.append(entry)
+
+    return args_list
+
+
+def format_table(args_list: list[dict]) -> str:
+    """Format extracted args as a markdown table."""
+    lines = []
+    lines.append(f"*{app_name} v{app_version}* — run `uv run run.py --help` for latest options.")
+    lines.append("")
+    lines.append("| Flag | Description | Default | Choices |")
+    lines.append("|------|-------------|---------|---------|")
+
+    for arg in args_list:
+        # Skip version action — not a real argument
+        if arg["action"] == "version":
+            continue
+
+        flags = f"`{arg['flags']}`"
+        desc = arg["help"]
+
+        # Format default display
+        default = arg["default"]
+        if arg["action"] == "store_true":
+            # Show actual default (usually False, but --keep-audio defaults True)
+            if default == "True":
+                default = "`True`"
+            else:
+                default = "`False`"
+        elif default:
+            default = f"`{default}`"
+
+        choices = arg["choices"]
+        if choices:
+            choices = f"`{choices}`"
+
+        lines.append(f"| {flags} | {desc} | {default} | {choices} |")
+
+    return "\n".join(lines)
+
+
+def generate_cli_docs() -> str:
+    """Read core.py source and return the formatted CLI docs markdown."""
+    source = CORE_PY.read_text()
+    args_list = extract_args(source)
+    return format_table(args_list)
+
+
+def update_readme(table: str) -> bool:
+    """Replace content between markers in README.md. Returns True if changed."""
+    content = README_MD.read_text()
+
+    if START_MARKER not in content or END_MARKER not in content:
+        print(f"ERROR: Markers {START_MARKER} / {END_MARKER} not found in README.md", file=sys.stderr)
+        return False
+
+    before = content[: content.index(START_MARKER) + len(START_MARKER)]
+    after = content[content.index(END_MARKER) :]
+
+    new_content = f"{before}\n{table}\n{after}"
+
+    if new_content == content:
+        return False
+
+    README_MD.write_text(new_content)
+    return True
+
+
+def main() -> None:
+    table = generate_cli_docs()
+
+    if "--stdout" in sys.argv:
+        print(table)
+        return
+
+    if "--check" in sys.argv:
+        content = README_MD.read_text()
+        if START_MARKER not in content or END_MARKER not in content:
+            print("ERROR: CLI_ARGS markers not found in README.md", file=sys.stderr)
+            sys.exit(1)
+
+        before = content[: content.index(START_MARKER) + len(START_MARKER)]
+        after = content[content.index(END_MARKER) :]
+        expected = f"{before}\n{table}\n{after}"
+
+        if content != expected:
+            print("README.md CLI args section is stale. Run: uv run scripts/generate_cli_docs.py", file=sys.stderr)
+            sys.exit(1)
+
+        print("README.md CLI args section is up to date.")
+        return
+
+    changed = update_readme(table)
+    if changed:
+        print("README.md updated with current CLI args.")
+    else:
+        print("README.md already up to date.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/generate_cli_docs.py — AST-based CLI docs generator."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the generator module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from generate_cli_docs import (
+    CORE_PY,
+    extract_args,
+    format_table,
+    generate_cli_docs,
+)
+
+
+@pytest.fixture
+def core_source() -> str:
+    return CORE_PY.read_text()
+
+
+@pytest.fixture
+def extracted_args(core_source: str) -> list[dict]:
+    return extract_args(core_source)
+
+
+class TestExtractArgs:
+    def test_finds_expected_arg_count(self, extracted_args: list[dict]) -> None:
+        """Should find all non-deprecated args (currently 26 including -v/--version)."""
+        # 30 total add_argument calls minus 4 deprecated = 26
+        assert len(extracted_args) == 26
+
+    def test_version_excluded_from_table(self, extracted_args: list[dict]) -> None:
+        """The -v/--version action=version arg is extracted but filtered in format_table."""
+        table = format_table(extracted_args)
+        assert "--version" not in table
+
+    def test_deprecated_args_excluded(self, core_source: str) -> None:
+        """Args with help=argparse.SUPPRESS should not appear."""
+        args = extract_args(core_source)
+        all_flags = " ".join(a["flags"] for a in args)
+        assert "--cpu-cores" not in all_flags
+        assert "--gpu-vendor" not in all_flags
+        assert "--gpu-threads" not in all_flags
+        assert "-f" not in all_flags.split(", ")
+
+    def test_source_arg_extracted(self, extracted_args: list[dict]) -> None:
+        """The -s/--source argument should be present with correct help text."""
+        source_args = [a for a in extracted_args if "--source" in a["flags"]]
+        assert len(source_args) == 1
+        assert source_args[0]["help"] == "select an source image"
+
+    def test_video_quality_choices(self, extracted_args: list[dict]) -> None:
+        """range(52) should resolve to '0-51'."""
+        vq_args = [a for a in extracted_args if "--video-quality" in a["flags"]]
+        assert len(vq_args) == 1
+        assert vq_args[0]["choices"] == "0-51"
+
+    def test_keyframe_interval_choices(self, extracted_args: list[dict]) -> None:
+        """range(2, 11) should resolve to '2-10'."""
+        ki_args = [a for a in extracted_args if "--keyframe-interval" in a["flags"]]
+        assert len(ki_args) == 1
+        assert ki_args[0]["choices"] == "2-10"
+
+    def test_max_memory_default_is_auto(self, extracted_args: list[dict]) -> None:
+        """suggest_max_memory() should resolve to '(auto)'."""
+        mm_args = [a for a in extracted_args if "--max-memory" in a["flags"]]
+        assert len(mm_args) == 1
+        assert mm_args[0]["default"] == "(auto)"
+
+    def test_frame_processor_has_choices(self, extracted_args: list[dict]) -> None:
+        """--frame-processor should list all processor choices."""
+        fp_args = [a for a in extracted_args if "--frame-processor" in a["flags"]]
+        assert len(fp_args) == 1
+        assert "face_swapper" in fp_args[0]["choices"]
+        assert "face_enhancer" in fp_args[0]["choices"]
+
+
+class TestFormatTable:
+    def test_output_is_valid_markdown_table(self, extracted_args: list[dict]) -> None:
+        """Output should have header, separator, and data rows."""
+        table = format_table(extracted_args)
+        lines = table.strip().split("\n")
+        # Line 0: version info, line 1: blank, line 2: header, line 3: separator, line 4+: data
+        assert "| Flag |" in lines[2]
+        assert "|---" in lines[3]
+        # 25 data rows (26 extracted minus -v/--version filtered by format_table)
+        non_version_count = sum(1 for a in extracted_args if a["action"] != "version")
+        assert len(lines) >= 4 + non_version_count
+
+    def test_store_true_default_shows_false(self, extracted_args: list[dict]) -> None:
+        """store_true actions should show False as default."""
+        table = format_table(extracted_args)
+        # --keep-fps is store_true with default=False
+        assert "`False`" in table
+
+
+class TestGenerateCliDocs:
+    def test_generates_non_empty_output(self) -> None:
+        table = generate_cli_docs()
+        assert len(table) > 100
+        assert "| Flag |" in table
+
+    def test_contains_version_info(self) -> None:
+        table = generate_cli_docs()
+        assert "v2.0.3c" in table
+
+
+class TestCheckMode:
+    def test_check_passes_when_fresh(self, tmp_path: Path) -> None:
+        """--check should exit 0 when README matches generated content."""
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve().parent.parent / "scripts" / "generate_cli_docs.py"), "--stdout"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "| Flag |" in result.stdout


### PR DESCRIPTION
## Summary

- Rewrite README from ~400 to ~230 lines — removes outdated pip/venv instructions, wrong hardcoded version (2.0.5c → actual 2.0.3c), commercial pre-built download section, and verbose per-platform GPU setup blocks
- Add AST-based CLI docs generator (`scripts/generate_cli_docs.py`) that parses `modules/core.py` to extract all `add_argument()` calls — no heavy imports needed
- CLI args table is now auto-generated between `<!-- CLI_ARGS_START/END -->` markers, includes all 25 current flags (was missing `--rife`, `--half-rate`, `--keyframe-interval`, `--rife-model`, `--rife-multiplier`, `--nsfw-filter`)
- Add justfile recipes `generate-cli-docs` and `check-cli-docs` (CI staleness check)

## Test plan

- [x] `uv run scripts/generate_cli_docs.py --stdout` — verify table looks correct
- [x] `uv run scripts/generate_cli_docs.py --check` — exits 0 (README is fresh)
- [x] `uv run pytest tests/test_generate_cli_docs.py -v` — 13 tests pass
- [x] `uv run pytest tests/ -x -q` — all 165 tests pass (no regressions)
- [ ] Visual review of README.md on GitHub (check GIFs render, table formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)