### PR TITLE
feat(enhancer): add skip-frame enhancement for webcam

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -97,4 +97,7 @@ rife_multiplier: int = 2              # Frame rate multiplier: 2 = double fps, 4
 half_rate_processing: bool = False    # Process every Nth frame; use RIFE to fill skipped frames
 keyframe_interval: int = 2            # Run face processing every Nth frame (2-10)
 
+# --- Enhancer Skip-Frame ---
+enhancer_skip_interval: int = 1      # Enhance every Nth frame (1=every, 2=every other, etc.)
+
 # --- END OF FILE globals.py ---

--- a/modules/ui_webcam.py
+++ b/modules/ui_webcam.py
@@ -19,6 +19,26 @@ from modules.video_capture import VideoCapturer
 # own dedicated thread.
 DETECT_EVERY_N = 2
 
+# Enhancer processor names for skip-frame logic
+_ENHANCER_NAMES = frozenset({
+    "DLC.FACE-ENHANCER",
+    "DLC.FACE-ENHANCER-GPEN256",
+    "DLC.FACE-ENHANCER-GPEN512",
+})
+
+# Map from processor NAME to fp_ui toggle key
+_ENHANCER_UI_KEYS = {
+    "DLC.FACE-ENHANCER": "face_enhancer",
+    "DLC.FACE-ENHANCER-GPEN256": "face_enhancer_gpen256",
+    "DLC.FACE-ENHANCER-GPEN512": "face_enhancer_gpen512",
+}
+
+
+def _is_enhancer_enabled(processor) -> bool:
+    """Check if an enhancer processor is toggled on in the UI."""
+    key = _ENHANCER_UI_KEYS.get(processor.NAME)
+    return key is not None and modules.globals.fp_ui.get(key, False)
+
 
 def _capture_thread_func(cap, capture_queue, stop_event):
     """Capture thread: reads frames from camera and puts them into the queue.
@@ -92,6 +112,8 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
     rife_warned = False
     half_rate_warned = False
     frame_counter = 0
+    enhancer_frame_counter = 0
+    prev_enhanced_frame = None
 
     while not stop_event.is_set():
         try:
@@ -134,16 +156,19 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
                 elif cached_target_face is not None:
                     cached_faces_list = [cached_target_face]
 
+                # Enhancer skip-frame: compute once per frame whether to skip enhancement
+                enhancer_frame_counter += 1
+                enh_interval = max(1, getattr(modules.globals, "enhancer_skip_interval", 1))
+                skip_enhancer = enh_interval > 1 and (enhancer_frame_counter % enh_interval) != 1
+
                 for frame_processor in frame_processors:
-                    if frame_processor.NAME == "DLC.FACE-ENHANCER":
-                        if modules.globals.fp_ui.get("face_enhancer"):
-                            temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
-                    elif frame_processor.NAME == "DLC.FACE-ENHANCER-GPEN256":
-                        if modules.globals.fp_ui.get("face_enhancer_gpen256"):
-                            temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
-                    elif frame_processor.NAME == "DLC.FACE-ENHANCER-GPEN512":
-                        if modules.globals.fp_ui.get("face_enhancer_gpen512"):
-                            temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
+                    if frame_processor.NAME in _ENHANCER_NAMES:
+                        if _is_enhancer_enabled(frame_processor):
+                            if skip_enhancer and prev_enhanced_frame is not None:
+                                temp_frame = prev_enhanced_frame
+                            else:
+                                temp_frame = frame_processor.process_frame(None, temp_frame, faces=cached_faces_list)
+                                prev_enhanced_frame = temp_frame.copy()
                     elif frame_processor.NAME == "DLC.FACE-SWAPPER":
                         # Use cached face positions to skip redundant detection
                         swapped_bboxes = []
@@ -165,14 +190,20 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
                         temp_frame = frame_processor.process_frame(source_image, temp_frame)
             else:
                 modules.globals.target_path = None
+
+                # Enhancer skip-frame for map_faces path
+                enhancer_frame_counter += 1
+                enh_interval = max(1, getattr(modules.globals, "enhancer_skip_interval", 1))
+                skip_enhancer = enh_interval > 1 and (enhancer_frame_counter % enh_interval) != 1
+
                 for frame_processor in frame_processors:
-                    if frame_processor.NAME == "DLC.FACE-ENHANCER":
-                        if modules.globals.fp_ui.get("face_enhancer"):
-                            temp_frame = frame_processor.process_frame_v2(temp_frame)
-                    elif frame_processor.NAME in ("DLC.FACE-ENHANCER-GPEN256", "DLC.FACE-ENHANCER-GPEN512"):
-                        fp_key = "face_enhancer_gpen256" if "256" in frame_processor.NAME else "face_enhancer_gpen512"
-                        if modules.globals.fp_ui.get(fp_key):
-                            temp_frame = frame_processor.process_frame_v2(temp_frame)
+                    if frame_processor.NAME in _ENHANCER_NAMES:
+                        if _is_enhancer_enabled(frame_processor):
+                            if skip_enhancer and prev_enhanced_frame is not None:
+                                temp_frame = prev_enhanced_frame
+                            else:
+                                temp_frame = frame_processor.process_frame_v2(temp_frame)
+                                prev_enhanced_frame = temp_frame.copy()
                     else:
                         temp_frame = frame_processor.process_frame(None, temp_frame)
         else:

--- a/tests/test_enhancer_skip.py
+++ b/tests/test_enhancer_skip.py
@@ -1,0 +1,229 @@
+"""Tests for enhancer skip-frame optimization (Issue #33).
+
+Enhancer skip-frame mode reuses the previous enhanced result on skipped frames,
+reducing GFPGAN/GPEN compute cost while maintaining visual quality through
+temporal coherence.
+"""
+import numpy as np
+import pytest
+
+import modules.globals
+
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+
+
+class TestEnhancerSkipGlobals:
+    """Test that enhancer_skip_interval exists with correct defaults."""
+
+    def test_globals_has_enhancer_skip_interval(self):
+        assert hasattr(modules.globals, "enhancer_skip_interval")
+
+    def test_enhancer_skip_interval_default_is_1(self):
+        """Default of 1 means no skipping (every frame enhanced)."""
+        assert modules.globals.enhancer_skip_interval == 1
+
+    def test_enhancer_skip_interval_is_int(self):
+        assert isinstance(modules.globals.enhancer_skip_interval, int)
+
+
+# ---------------------------------------------------------------------------
+# Skip formula
+# ---------------------------------------------------------------------------
+
+
+class TestSkipFormula:
+    """Unit-test the enhancer skip formula from _processing_thread_func."""
+
+    @staticmethod
+    def _should_skip(enhancer_frame_counter: int, interval: int) -> bool:
+        """Replicate the skip formula from ui_webcam.py."""
+        interval = max(1, interval)
+        return interval > 1 and (enhancer_frame_counter % interval) != 1
+
+    def test_skip_formula_interval_1(self):
+        """interval=1 means never skip (every frame enhanced)."""
+        for counter in range(1, 20):
+            assert self._should_skip(counter, 1) is False
+
+    def test_skip_formula_interval_2(self):
+        """interval=2 means skip every other frame.
+
+        Frame 1: counter=1, 1%2=1 -> no skip (enhance)
+        Frame 2: counter=2, 2%2=0 -> skip
+        Frame 3: counter=3, 3%2=1 -> no skip (enhance)
+        Frame 4: counter=4, 4%2=0 -> skip
+        """
+        results = [self._should_skip(i, 2) for i in range(1, 9)]
+        # Enhance, skip, enhance, skip, ...
+        assert results == [False, True, False, True, False, True, False, True]
+
+    def test_skip_formula_interval_3(self):
+        """interval=3 means skip 2 out of every 3 frames.
+
+        Frame 1: counter=1, 1%3=1 -> no skip (enhance)
+        Frame 2: counter=2, 2%3=2 -> skip
+        Frame 3: counter=3, 3%3=0 -> skip
+        Frame 4: counter=4, 4%3=1 -> no skip (enhance)
+        """
+        results = [self._should_skip(i, 3) for i in range(1, 10)]
+        assert results == [False, True, True, False, True, True, False, True, True]
+
+    def test_no_skip_on_first_frame(self):
+        """First frame (counter=1) is never skipped regardless of interval."""
+        for interval in range(1, 11):
+            assert self._should_skip(1, interval) is False, (
+                f"First frame should not be skipped with interval={interval}"
+            )
+
+    def test_skip_formula_interval_0_treated_as_1(self):
+        """interval=0 is clamped to 1 via max(1, interval), so never skip."""
+        for counter in range(1, 10):
+            assert self._should_skip(counter, 0) is False
+
+
+# ---------------------------------------------------------------------------
+# Frame hold on skip
+# ---------------------------------------------------------------------------
+
+
+class TestFrameHoldOnSkip:
+    """When skipping, the previous enhanced frame is returned."""
+
+    @staticmethod
+    def _make_frame(fill: int = 0) -> np.ndarray:
+        return np.full((480, 640, 3), fill, dtype=np.uint8)
+
+    def test_frame_hold_on_skip(self):
+        """When skip_enhancer=True and prev_enhanced_frame exists, use cached frame."""
+        prev_enhanced = self._make_frame(50)
+        current_frame = self._make_frame(100)
+
+        skip_enhancer = True
+        if skip_enhancer and prev_enhanced is not None:
+            result = prev_enhanced
+        else:
+            result = current_frame
+
+        assert np.array_equal(result, prev_enhanced)
+        assert not np.array_equal(result, current_frame)
+
+    def test_no_skip_on_first_frame_no_cache(self):
+        """When prev_enhanced_frame is None (first frame), enhancer must run."""
+        prev_enhanced = None
+        current_frame = self._make_frame(100)
+
+        skip_enhancer = True  # would skip, but no cache available
+        if skip_enhancer and prev_enhanced is not None:
+            result = prev_enhanced
+        else:
+            result = current_frame  # falls through to actual enhancement
+
+        assert np.array_equal(result, current_frame)
+
+    def test_cache_updated_on_enhance(self):
+        """When not skipping, the result is cached for future skip frames."""
+        enhanced_result = self._make_frame(75)
+        prev_enhanced = None
+
+        skip_enhancer = False
+        # Simulate: enhancer runs and produces enhanced_result
+        result = enhanced_result
+        prev_enhanced = result.copy()
+
+        assert prev_enhanced is not None
+        assert np.array_equal(prev_enhanced, enhanced_result)
+
+
+# ---------------------------------------------------------------------------
+# Independence from half-rate processing
+# ---------------------------------------------------------------------------
+
+
+class TestEnhancerSkipIndependentOfHalfRate:
+    """Both enhancer skip and half-rate can be active simultaneously."""
+
+    @staticmethod
+    def _half_rate_skip(frame_counter: int, keyframe_interval: int) -> bool:
+        return (frame_counter % keyframe_interval) != 1
+
+    @staticmethod
+    def _enhancer_skip(enhancer_counter: int, interval: int) -> bool:
+        interval = max(1, interval)
+        return interval > 1 and (enhancer_counter % interval) != 1
+
+    def test_both_active_independently(self):
+        """Half-rate and enhancer skip use separate counters and don't interfere."""
+        keyframe_interval = 2
+        enhancer_interval = 3
+        frame_counter = 0
+        enhancer_counter = 0
+
+        half_rate_skips = []
+        enhancer_skips = []
+
+        for _ in range(9):
+            frame_counter += 1
+            hr_skip = self._half_rate_skip(frame_counter, keyframe_interval)
+            half_rate_skips.append(hr_skip)
+
+            if not hr_skip:
+                # Only increment enhancer counter on keyframes (when face processing runs)
+                enhancer_counter += 1
+                enhancer_skips.append(self._enhancer_skip(enhancer_counter, enhancer_interval))
+            else:
+                enhancer_skips.append(None)  # enhancer doesn't run on half-rate skips
+
+        # Half-rate: skip on even frames (2,4,6,8)
+        assert half_rate_skips == [False, True, False, True, False, True, False, True, False]
+
+        # Enhancer runs on keyframes (1,3,5,7,9) with its own counter (1,2,3,4,5)
+        # interval=3: skip when counter%3 != 1 -> skip on counter 2,3,5
+        # counter 1: no skip, counter 2: skip, counter 3: skip, counter 4: no skip, counter 5: skip
+        assert enhancer_skips == [False, None, True, None, True, None, False, None, True]
+
+
+# ---------------------------------------------------------------------------
+# Helper function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnhancerHelpers:
+    """Test the _ENHANCER_NAMES set and _is_enhancer_enabled helper."""
+
+    def test_enhancer_names_contains_all_variants(self):
+        from modules.ui_webcam import _ENHANCER_NAMES
+        assert "DLC.FACE-ENHANCER" in _ENHANCER_NAMES
+        assert "DLC.FACE-ENHANCER-GPEN256" in _ENHANCER_NAMES
+        assert "DLC.FACE-ENHANCER-GPEN512" in _ENHANCER_NAMES
+
+    def test_enhancer_names_excludes_swapper(self):
+        from modules.ui_webcam import _ENHANCER_NAMES
+        assert "DLC.FACE-SWAPPER" not in _ENHANCER_NAMES
+
+    def test_is_enhancer_enabled_checks_fp_ui(self):
+        from modules.ui_webcam import _is_enhancer_enabled
+        from unittest.mock import MagicMock
+
+        processor = MagicMock()
+        processor.NAME = "DLC.FACE-ENHANCER"
+
+        original = modules.globals.fp_ui.copy()
+        try:
+            modules.globals.fp_ui["face_enhancer"] = True
+            assert _is_enhancer_enabled(processor) is True
+
+            modules.globals.fp_ui["face_enhancer"] = False
+            assert _is_enhancer_enabled(processor) is False
+        finally:
+            modules.globals.fp_ui = original
+
+    def test_is_enhancer_enabled_unknown_processor(self):
+        from modules.ui_webcam import _is_enhancer_enabled
+        from unittest.mock import MagicMock
+
+        processor = MagicMock()
+        processor.NAME = "DLC.FACE-SWAPPER"
+        assert _is_enhancer_enabled(processor) is False


### PR DESCRIPTION
## Summary
- Adds `enhancer_skip_interval` global (default 1 = no skip) to control how often the face enhancer runs during live webcam preview
- When interval > 1, skipped frames reuse the previous enhanced result instead of re-running GFPGAN/GPEN inference
- Extracts `_ENHANCER_NAMES` set and `_is_enhancer_enabled()` helper to unify enhancer handling across both map_faces and non-map_faces branches
- 16 new tests covering skip formula, frame hold behavior, and independence from half-rate processing

Closes #33

## Merge strategy
**Phase 1** — independent, can merge in any order alongside #37 and #38.

## Test plan
- [ ] Run `uv run pytest tests/test_enhancer_skip.py -v` — all 16 tests pass
- [ ] Run full suite `uv run pytest tests/ -v` — no regressions
- [ ] Manual: enable face_enhancer + set `enhancer_skip_interval=3`, verify FPS improvement with webcam
- [ ] Manual: combine with `half_rate_processing=True`, verify both features work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>