### PR TITLE
perf(enhancer): use INTER_AREA for post-inference downscale

### DIFF
--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -326,7 +326,7 @@ def enhance_face(temp_frame: Frame, faces=None) -> Frame:
                 enhanced_bgr = cv2.resize(
                     enhanced_bgr,
                     (align_size, align_size),
-                    interpolation=cv2.INTER_LANCZOS4,
+                    interpolation=cv2.INTER_AREA,
                 )
 
             # Paste enhanced face back onto the frame

--- a/tests/test_face_enhancer.py
+++ b/tests/test_face_enhancer.py
@@ -1,4 +1,5 @@
 """Tests for modules/processors/frame/face_enhancer.py."""
+import cv2
 import numpy as np
 import pytest
 from unittest.mock import patch, MagicMock
@@ -39,3 +40,49 @@ def test_enhance_face_handles_runtime_error():
                    side_effect=RuntimeError("Model load failed")):
             result = face_enhancer.enhance_face(frame)
             assert np.array_equal(result, frame)
+
+
+def test_enhance_face_uses_inter_area_for_downscale():
+    """The post-inference resize should use INTER_AREA for downscaling."""
+    from modules.processors.frame import face_enhancer
+
+    # Mock face with valid landmarks
+    mock_face = MagicMock()
+    mock_face.kps = np.array(
+        [[10, 10], [20, 10], [15, 20], [10, 25], [20, 25]], dtype=np.float32
+    )
+
+    # Mock session that outputs larger resolution than input
+    mock_session = MagicMock()
+    mock_input = MagicMock()
+    mock_input.name = "input"
+    mock_input.shape = [1, 3, 512, 512]
+    mock_input.type = "tensor(float)"
+    mock_session.get_inputs.return_value = [mock_input]
+    mock_output = MagicMock()
+    mock_output.name = "output"
+    mock_output.shape = [1, 3, 1024, 1024]
+    mock_output.type = "tensor(float)"
+    mock_session.get_outputs.return_value = [mock_output]
+    # Return a 1024x1024 output tensor
+    mock_session.run.return_value = [np.zeros((1, 3, 1024, 1024), dtype=np.float32)]
+
+    frame = np.zeros((480, 640, 3), dtype=np.uint8)
+
+    with patch(
+        "modules.processors.frame.face_enhancer.get_many_faces",
+        return_value=[mock_face],
+    ):
+        with patch(
+            "modules.processors.frame.face_enhancer.get_face_enhancer",
+            return_value=mock_session,
+        ):
+            with patch("cv2.resize", wraps=cv2.resize) as mock_resize:
+                face_enhancer.enhance_face(frame)
+                # Find the resize call that does the downscale (1024->512)
+                for call in mock_resize.call_args_list:
+                    args, kwargs = call
+                    if "interpolation" in kwargs:
+                        assert kwargs["interpolation"] == cv2.INTER_AREA, (
+                            f"Expected INTER_AREA, got {kwargs['interpolation']}"
+                        )


### PR DESCRIPTION
## Summary
- Changes `cv2.INTER_LANCZOS4` → `cv2.INTER_AREA` at `face_enhancer.py:329` for the post-GFPGAN resize (1024→512)
- `INTER_AREA` uses a box filter that is both faster and produces better results when downscaling vs the 8-tap sinc of LANCZOS4
- 1 new test verifying the interpolation method

Closes #34

## Merge strategy
**Phase 2** — merge after #35 and #36 (touches same file, non-overlapping region). Rebase onto main after #36 merges.

## Test plan
- [ ] Run `uv run pytest tests/test_face_enhancer.py -v` — all tests pass
- [ ] Run full suite — no regressions
- [ ] Visual: compare output quality (should be identical or slightly sharper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>