### PR TITLE
feat(enhancer): add FP16 GFPGAN model support and conversion

### DIFF
--- a/justfile
+++ b/justfile
@@ -65,6 +65,11 @@ benchmark-mlx *args:
 check-blas:
     uv run python -c "from modules.blas_check import check_apple_silicon_blas, log_blas_config; import logging; logging.basicConfig(level=logging.INFO); log_blas_config(); check_apple_silicon_blas()"
 
+# Convert GFPGAN ONNX model from FP32 to FP16 for faster inference
+[group: "setup"]
+convert-gfpgan-fp16:
+    uv run scripts/convert_gfpgan_fp16.py
+
 ##########
 # Run
 ##########

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -44,7 +44,10 @@ FFHQ_TEMPLATE_512 = np.array(
 
 
 def pre_check() -> bool:
-    model_path = os.path.join(MODELS_DIR, "gfpgan-1024.onnx")
+    # Prefer FP16 model for faster inference if available
+    fp16_path = os.path.join(MODELS_DIR, "gfpgan-1024-fp16.onnx")
+    fp32_path = os.path.join(MODELS_DIR, "gfpgan-1024.onnx")
+    model_path = fp16_path if os.path.exists(fp16_path) else fp32_path
     if not os.path.exists(model_path):
         update_status("Downloading gfpgan-1024.onnx...", NAME)
         conditional_download(
@@ -81,7 +84,10 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
 
     with THREAD_LOCK:
         if FACE_ENHANCER is None:
-            model_path = os.path.join(MODELS_DIR, "gfpgan-1024.onnx")
+            # Prefer FP16 model for faster inference if available
+            fp16_path = os.path.join(MODELS_DIR, "gfpgan-1024-fp16.onnx")
+            fp32_path = os.path.join(MODELS_DIR, "gfpgan-1024.onnx")
+            model_path = fp16_path if os.path.exists(fp16_path) else fp32_path
 
             if not os.path.exists(model_path):
                 conditional_download(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,5 @@ rife = ["rife-ncnn-vulkan-python-tntwise>=1.4.0"]
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "onnxconverter-common>=1.14.0",
 ]

--- a/scripts/convert_gfpgan_fp16.py
+++ b/scripts/convert_gfpgan_fp16.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Convert GFPGAN ONNX model from FP32 to FP16.
+
+Usage:
+    uv run scripts/convert_gfpgan_fp16.py [--input models/gfpgan-1024.onnx] [--output models/gfpgan-1024-fp16.onnx]
+"""
+import argparse
+import os
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert GFPGAN ONNX model to FP16")
+    parser.add_argument(
+        "--input",
+        default=os.path.join("models", "gfpgan-1024.onnx"),
+        help="Path to FP32 ONNX model (default: models/gfpgan-1024.onnx)",
+    )
+    parser.add_argument(
+        "--output",
+        default=os.path.join("models", "gfpgan-1024-fp16.onnx"),
+        help="Path for FP16 output (default: models/gfpgan-1024-fp16.onnx)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"Error: Input model not found: {args.input}")
+        sys.exit(1)
+
+    try:
+        import onnx
+        from onnxconverter_common import float16
+    except ImportError:
+        print("Error: Required packages not installed.")
+        print("Install with: uv pip install onnxconverter-common")
+        sys.exit(1)
+
+    print(f"Loading FP32 model: {args.input}")
+    model = onnx.load(args.input)
+
+    print("Converting to FP16 (keeping IO types as FP32)...")
+    model_fp16 = float16.convert_float_to_float16(model, keep_io_types=True)
+
+    print(f"Saving FP16 model: {args.output}")
+    onnx.save(model_fp16, args.output)
+
+    input_size = os.path.getsize(args.input) / (1024 * 1024)
+    output_size = os.path.getsize(args.output) / (1024 * 1024)
+    reduction = (1 - output_size / input_size) * 100
+    print(f"Size: {input_size:.1f} MB -> {output_size:.1f} MB ({reduction:.0f}% reduction)")
+    print("Done! Test with: uv run run.py --execution-provider coreml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gfpgan_fp16_convert.py
+++ b/tests/test_gfpgan_fp16_convert.py
@@ -1,0 +1,97 @@
+"""Tests for FP16 GFPGAN model preference and conversion script."""
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+import numpy as np
+
+
+def test_get_face_enhancer_prefers_fp16(tmp_path):
+    """get_face_enhancer should prefer the FP16 model when both exist."""
+    from modules.processors.frame import face_enhancer
+
+    fp16_path = str(tmp_path / "gfpgan-1024-fp16.onnx")
+    fp32_path = str(tmp_path / "gfpgan-1024.onnx")
+
+    # Create dummy files
+    open(fp16_path, "w").close()
+    open(fp32_path, "w").close()
+
+    # Reset singleton
+    face_enhancer.FACE_ENHANCER = None
+
+    with patch.object(face_enhancer, "MODELS_DIR", str(tmp_path)):
+        with patch("onnxruntime.InferenceSession") as mock_session:
+            mock_inst = MagicMock()
+            mock_input = MagicMock()
+            mock_input.name = "input"
+            mock_input.shape = [1, 3, 512, 512]
+            mock_input.type = "tensor(float)"
+            mock_inst.get_inputs.return_value = [mock_input]
+            mock_output = MagicMock()
+            mock_output.name = "output"
+            mock_output.shape = [1, 3, 1024, 1024]
+            mock_output.type = "tensor(float)"
+            mock_inst.get_outputs.return_value = [mock_output]
+            mock_inst.get_providers.return_value = ["CPUExecutionProvider"]
+            mock_session.return_value = mock_inst
+
+            face_enhancer.get_face_enhancer()
+
+            # Verify FP16 path was used
+            call_args = mock_session.call_args
+            assert "fp16" in call_args[0][0]
+
+    # Clean up singleton
+    face_enhancer.FACE_ENHANCER = None
+
+
+def test_get_face_enhancer_falls_back_to_fp32(tmp_path):
+    """get_face_enhancer should fall back to FP32 when FP16 doesn't exist."""
+    from modules.processors.frame import face_enhancer
+
+    fp32_path = str(tmp_path / "gfpgan-1024.onnx")
+    open(fp32_path, "w").close()
+
+    face_enhancer.FACE_ENHANCER = None
+
+    with patch.object(face_enhancer, "MODELS_DIR", str(tmp_path)):
+        with patch("onnxruntime.InferenceSession") as mock_session:
+            mock_inst = MagicMock()
+            mock_input = MagicMock()
+            mock_input.name = "input"
+            mock_input.shape = [1, 3, 512, 512]
+            mock_input.type = "tensor(float)"
+            mock_inst.get_inputs.return_value = [mock_input]
+            mock_output = MagicMock()
+            mock_output.name = "output"
+            mock_output.shape = [1, 3, 1024, 1024]
+            mock_output.type = "tensor(float)"
+            mock_inst.get_outputs.return_value = [mock_output]
+            mock_inst.get_providers.return_value = ["CPUExecutionProvider"]
+            mock_session.return_value = mock_inst
+
+            face_enhancer.get_face_enhancer()
+
+            call_args = mock_session.call_args
+            assert "fp16" not in call_args[0][0]
+            assert "gfpgan-1024.onnx" in call_args[0][0]
+
+    face_enhancer.FACE_ENHANCER = None
+
+
+def test_pre_check_accepts_fp16_model(tmp_path):
+    """pre_check should succeed when only FP16 model exists."""
+    from modules.processors.frame import face_enhancer
+
+    fp16_path = str(tmp_path / "gfpgan-1024-fp16.onnx")
+    open(fp16_path, "w").close()
+
+    with patch.object(face_enhancer, "MODELS_DIR", str(tmp_path)):
+        with patch.object(face_enhancer, "conditional_download"):
+            result = face_enhancer.pre_check()
+            assert result is True
+
+
+def test_conversion_script_exists():
+    """The conversion script should exist."""
+    assert os.path.exists("scripts/convert_gfpgan_fp16.py")


### PR DESCRIPTION
## Summary
- Adds `scripts/convert_gfpgan_fp16.py` conversion script using `onnxconverter-common`
- `get_face_enhancer()` and `pre_check()` now prefer `gfpgan-1024-fp16.onnx` with automatic FP32 fallback
- Adds `just convert-gfpgan-fp16` recipe and `onnxconverter-common` dev dependency
- FP16 reduces model size ~50% and can speed up inference on FP16-capable GPUs
- 4 new tests covering FP16 preference, FP32 fallback, pre_check acceptance, and script existence

Closes #37

## Merge strategy
**Phase 1** — independent, can merge in any order alongside #33 and #38.

## Follow-up
- After merging, run `just convert-gfpgan-fp16` to generate the FP16 model locally
- Run `uv sync` to install the new dev dependency

## Test plan
- [ ] Run `uv run pytest tests/test_gfpgan_fp16_convert.py -v` — all 4 tests pass
- [ ] Run full suite — no regressions
- [ ] Manual: run conversion script, verify ~50% size reduction
- [ ] Manual: run enhancer with FP16 model, verify visual quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>