### PR TITLE
feat(ui): unified face mapping list replaces Map Faces toggle

### DIFF
--- a/modules/mapping_list.py
+++ b/modules/mapping_list.py
@@ -1,0 +1,211 @@
+"""Unified face mapping list data model (Unified Face Mapping UI).
+
+Pure data model with no Tkinter dependency.  Manages an ordered list of
+source→target(pin) mapping entries and exposes derived state for the
+processing pipeline.
+
+Usage::
+
+    from modules.mapping_list import MAPPING_LIST
+
+    MAPPING_LIST.set_source(0, "/face.png", cv2_img, face_obj)
+    MAPPING_LIST.add_entry()
+    MAPPING_LIST.sync_to_store(STORE)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import numpy as np
+
+
+@dataclass
+class MappingEntry:
+    """A single source→target(pin) mapping."""
+    id: int
+    source_path: str | None = None
+    source_face: Any | None = None
+    source_cv2: np.ndarray | None = None
+    pin_path: str | None = None
+    pin_face: Any | None = None
+    pin_cv2: np.ndarray | None = None
+
+
+class MappingList:
+    """Ordered list of face mapping entries with change notification.
+
+    Starts with a single empty entry (matching current single-source UI).
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[MappingEntry] = [MappingEntry(id=0)]
+        self._next_id: int = 1
+        self._on_change: list[Callable[[], None]] = []
+
+    def _notify(self) -> None:
+        for cb in self._on_change:
+            cb()
+
+    def on_change(self, callback: Callable[[], None]) -> None:
+        self._on_change.append(callback)
+
+    # ------------------------------------------------------------------
+    # Entry management
+    # ------------------------------------------------------------------
+
+    def add_entry(self) -> MappingEntry:
+        entry = MappingEntry(id=self._next_id)
+        self._next_id += 1
+        self._entries.append(entry)
+        self._notify()
+        return entry
+
+    def remove_entry(self, entry_id: int) -> None:
+        self._entries = [e for e in self._entries if e.id != entry_id]
+        self._notify()
+
+    def clear_all(self) -> None:
+        self._entries.clear()
+        self._notify()
+
+    def get_entries(self) -> list[MappingEntry]:
+        return list(self._entries)
+
+    # ------------------------------------------------------------------
+    # Source / pin management
+    # ------------------------------------------------------------------
+
+    def set_source(
+        self,
+        entry_id: int,
+        path: str,
+        cv2_img: np.ndarray,
+        face: Any,
+    ) -> None:
+        for entry in self._entries:
+            if entry.id == entry_id:
+                entry.source_path = path
+                entry.source_cv2 = cv2_img
+                entry.source_face = face
+                self._notify()
+                return
+
+    def set_pin(
+        self,
+        entry_id: int,
+        path: str,
+        cv2_img: np.ndarray,
+        face: Any,
+    ) -> None:
+        for entry in self._entries:
+            if entry.id == entry_id:
+                entry.pin_path = path
+                entry.pin_cv2 = cv2_img
+                entry.pin_face = face
+                self._notify()
+                return
+
+    def clear_pin(self, entry_id: int) -> None:
+        for entry in self._entries:
+            if entry.id == entry_id:
+                entry.pin_path = None
+                entry.pin_cv2 = None
+                entry.pin_face = None
+                self._notify()
+                return
+
+    # ------------------------------------------------------------------
+    # Derived state
+    # ------------------------------------------------------------------
+
+    def effective_map_faces(self) -> bool:
+        """True when >1 entry or any entry has a pin set."""
+        if len(self._entries) > 1:
+            return True
+        return any(e.pin_path is not None for e in self._entries)
+
+    def effective_source_path(self) -> str | None:
+        """First entry's source_path (backward compat with globals.source_path)."""
+        if self._entries:
+            return self._entries[0].source_path
+        return None
+
+    def source_count(self) -> int:
+        """Number of entries that have a source face."""
+        return sum(1 for e in self._entries if e.source_face is not None)
+
+    # ------------------------------------------------------------------
+    # Sync to FaceMapStore
+    # ------------------------------------------------------------------
+
+    def sync_to_store(self, store: Any) -> None:
+        """Convert entries to FaceMapStore format and update the store.
+
+        Only entries with a source face are included.  If any entry has a pin,
+        ``store.simplify()`` is called to build the simple map.
+        """
+        store_entries: list[dict[str, Any]] = []
+        has_pins = False
+
+        for entry in self._entries:
+            if entry.source_face is None:
+                continue
+            store_entry: dict[str, Any] = {
+                'id': entry.id,
+                'source': {
+                    'cv2': entry.source_cv2,
+                    'face': entry.source_face,
+                },
+            }
+            if entry.pin_face is not None:
+                store_entry['target'] = {
+                    'cv2': entry.pin_cv2,
+                    'face': entry.pin_face,
+                }
+                has_pins = True
+            store_entries.append(store_entry)
+
+        store.set_entries(store_entries)
+        if has_pins:
+            store.simplify()
+
+    # ------------------------------------------------------------------
+    # Persistence (paths only — face objects are not serializable)
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> list[dict[str, Any]]:
+        result = []
+        for entry in self._entries:
+            d: dict[str, str | None] = {
+                'id': entry.id,
+                'source_path': entry.source_path,
+                'pin_path': entry.pin_path,
+            }
+            result.append(d)
+        return result
+
+    def restore_from_dict(self, data: list[dict]) -> None:
+        """Restore entries from serialized data (paths only)."""
+        self._entries.clear()
+        max_id = -1
+        for d in data:
+            entry_id = d.get('id', 0)
+            entry = MappingEntry(
+                id=entry_id,
+                source_path=d.get('source_path'),
+                pin_path=d.get('pin_path'),
+            )
+            self._entries.append(entry)
+            if entry_id > max_id:
+                max_id = entry_id
+        self._next_id = max_id + 1 if max_id >= 0 else 0
+
+    def restore_from_source_path(self, source_path: str) -> None:
+        """Migration: create single mapping from legacy source_path."""
+        self._entries = [MappingEntry(id=0, source_path=source_path)]
+        self._next_id = 1
+
+
+# Module-level singleton
+MAPPING_LIST: MappingList = MappingList()

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -22,6 +22,8 @@ from modules.utilities import (
 )
 from modules.gettext import LanguageManager
 from modules.ui_tooltip import ToolTip
+from modules.mapping_list import MAPPING_LIST
+from modules.ui_mapping_list import MappingListWidget
 import platform
 from modules.camera import get_available_cameras
 
@@ -144,6 +146,7 @@ _embedded_label = None          # CTkLabel inside embedded frame
 _popout_label = None            # CTkLabel inside PREVIEW CTkToplevel
 _preview_embedded = True        # True = embedded, False = pop-out window
 _embedded_preview_frame = None  # the collapsible frame widget
+_mapping_widget = None          # MappingListWidget instance
 
 
 def init(start: Callable[[], None], destroy: Callable[[], None], lang: str) -> ctk.CTk:
@@ -194,6 +197,7 @@ def save_switch_states():
         "live_max_fps": modules.globals.live_max_fps,
         "source_path": modules.globals.source_path,
         "target_path": modules.globals.target_path,
+        "mappings": MAPPING_LIST.to_dict(),
     }
     with open(_state_file_path(), "w") as f:
         json.dump(switch_states, f)
@@ -228,12 +232,22 @@ def load_switch_states():
         modules.globals.keyframe_interval = switch_states.get("keyframe_interval", 2)
         modules.globals.live_max_fps = switch_states.get("live_max_fps", 30)
         # Restore last-used paths; validate existence before accepting.
-        saved_source = switch_states.get("source_path")
-        if saved_source and os.path.isfile(saved_source):
-            modules.globals.source_path = saved_source
         saved_target = switch_states.get("target_path")
         if saved_target and os.path.isfile(saved_target):
             modules.globals.target_path = saved_target
+        # Restore mapping list from saved state, or migrate from legacy source_path
+        saved_mappings = switch_states.get("mappings")
+        if saved_mappings is not None:
+            MAPPING_LIST.restore_from_dict(saved_mappings)
+            modules.globals.source_path = MAPPING_LIST.effective_source_path()
+            modules.globals.map_faces = MAPPING_LIST.effective_map_faces()
+        else:
+            # Migration: old state file without "mappings" key
+            saved_source = switch_states.get("source_path")
+            if saved_source and os.path.isfile(saved_source):
+                MAPPING_LIST.restore_from_source_path(saved_source)
+                modules.globals.source_path = saved_source
+            modules.globals.map_faces = switch_states.get("map_faces", False)
         # Rebuild frame_processors from restored fp_ui so toggled enhancers
         # are included even if they weren't in the CLI --frame-processor list.
         _sync_enhancer_frame_processors()
@@ -242,12 +256,34 @@ def load_switch_states():
 
 
 def _restore_recent_paths() -> None:
-    """Populate image labels from saved paths after labels have been created."""
+    """Populate image labels from saved paths after labels have been created.
+
+    Source face thumbnails are now handled by MappingListWidget (it reads
+    source_cv2 from MappingEntry).  For restored paths without cv2 data,
+    we reload the images and detect faces so thumbnails render correctly.
+    """
     global RECENT_DIRECTORY_SOURCE, RECENT_DIRECTORY_TARGET
-    if modules.globals.source_path and is_image(modules.globals.source_path):
-        RECENT_DIRECTORY_SOURCE = os.path.dirname(modules.globals.source_path)
-        image = render_image_preview(modules.globals.source_path, SIDEBAR_THUMB_SIZE)
-        source_label.configure(image=image)
+
+    # Reload source face data for restored mappings (paths only, no cv2/face)
+    for entry in MAPPING_LIST.get_entries():
+        if entry.source_path and is_image(entry.source_path) and entry.source_face is None:
+            img = cv2.imread(entry.source_path)
+            if img is not None:
+                face = get_one_face(img)
+                if face is not None:
+                    x_min, y_min, x_max, y_max = face["bbox"]
+                    cropped = img[int(y_min):int(y_max), int(x_min):int(x_max)]
+                    MAPPING_LIST.set_source(entry.id, entry.source_path, cropped, face)
+            RECENT_DIRECTORY_SOURCE = os.path.dirname(entry.source_path)
+        if entry.pin_path and is_image(entry.pin_path) and entry.pin_face is None:
+            img = cv2.imread(entry.pin_path)
+            if img is not None:
+                face = get_one_face(img)
+                if face is not None:
+                    x_min, y_min, x_max, y_max = face["bbox"]
+                    cropped = img[int(y_min):int(y_max), int(x_min):int(x_max)]
+                    MAPPING_LIST.set_pin(entry.id, entry.pin_path, cropped, face)
+
     if modules.globals.target_path:
         if is_image(modules.globals.target_path):
             RECENT_DIRECTORY_TARGET = os.path.dirname(modules.globals.target_path)
@@ -283,8 +319,17 @@ def _setup_window(destroy: Callable) -> ctk.CTk:
     return root
 
 
+def _on_mapping_change() -> None:
+    """Observer callback: sync MappingList state to globals and FaceMapStore."""
+    from modules.face_map_store import STORE as _MAP_STORE
+    MAPPING_LIST.sync_to_store(_MAP_STORE)
+    modules.globals.source_path = MAPPING_LIST.effective_source_path()
+    modules.globals.map_faces = MAPPING_LIST.effective_map_faces()
+    save_switch_states()
+
+
 def _add_top_frame(root: ctk.CTk) -> None:
-    global source_label, target_label
+    global target_label, _mapping_widget
 
     top_frame = ctk.CTkFrame(root)
     top_frame.grid(row=0, column=0, sticky="ew", padx=5, pady=(10, 5))
@@ -292,20 +337,15 @@ def _add_top_frame(root: ctk.CTk) -> None:
     top_frame.columnconfigure(1, weight=0)
     top_frame.columnconfigure(2, weight=1)
 
-    # Source column
+    # Source column — inline mapping list replaces the old single source selector
     source_frame = ctk.CTkFrame(top_frame, fg_color="transparent")
     source_frame.grid(row=0, column=0, sticky="nsew", padx=3, pady=5)
     source_frame.columnconfigure(0, weight=1)
 
-    source_label = ctk.CTkLabel(source_frame, text=None, width=120, height=120)
-    source_label.grid(row=0, column=0, pady=(5, 5))
-
-    select_face_button = ctk.CTkButton(
-        source_frame, text=_("Select a face"), cursor="hand2",
-        command=lambda: select_source_path(),
+    _mapping_widget = MappingListWidget(
+        source_frame, MAPPING_LIST, on_change_callback=_on_mapping_change,
     )
-    select_face_button.grid(row=1, column=0, pady=(0, 5), sticky="ew", padx=5)
-    ToolTip(select_face_button, _("Choose the source face image to swap onto the target"))
+    MAPPING_LIST.on_change(_on_mapping_change)
 
     # Swap button
     swap_faces_button = ctk.CTkButton(
@@ -382,8 +422,6 @@ def _get_switch_defs():
              _("Display the mouth mask boundary for debugging")),
             (_("Swap All Faces"), "many_faces", False,
              _("Swap every detected face, not just the primary one")),
-            (_("Map Faces"), "map_faces", False,
-             _("Manually assign which source face maps to which target face")),
             (_("Seamless Blend"), "poisson_blend", False,
              _("Blend face edges smoothly into the target using Poisson blending")),
         ],
@@ -439,12 +477,6 @@ def _create_switch(
         command = lambda: (
             update_tumbler(key, value_var.get()),
             save_switch_states(),
-        )
-    elif attr == "map_faces":
-        command = lambda: (
-            setattr(modules.globals, attr, value_var.get()),
-            save_switch_states(),
-            close_mapper_window() if not value_var.get() else None,
         )
     else:
         command = lambda: (
@@ -942,6 +974,11 @@ def update_tumbler(var: str, value: bool) -> None:
 
 
 def select_source_path() -> None:
+    """Open file dialog and set source face for the first mapping entry.
+
+    Delegates to MappingListWidget's select handler for the first entry,
+    keeping backward compatibility with modules.globals.source_path.
+    """
     global RECENT_DIRECTORY_SOURCE, img_ft, vid_ft
 
     PREVIEW.withdraw()
@@ -951,14 +988,23 @@ def select_source_path() -> None:
         filetypes=[img_ft],
     )
     if is_image(source_path):
-        modules.globals.source_path = source_path
-        RECENT_DIRECTORY_SOURCE = os.path.dirname(modules.globals.source_path)
-        image = render_image_preview(modules.globals.source_path, SIDEBAR_THUMB_SIZE)
-        source_label.configure(image=image)
-        save_switch_states()
+        cv2_img = cv2.imread(source_path)
+        face = get_one_face(cv2_img)
+        if face is not None:
+            x_min, y_min, x_max, y_max = face["bbox"]
+            cropped = cv2_img[int(y_min):int(y_max), int(x_min):int(x_max)]
+            entries = MAPPING_LIST.get_entries()
+            entry_id = entries[0].id if entries else 0
+            MAPPING_LIST.set_source(entry_id, source_path, cropped, face)
+            RECENT_DIRECTORY_SOURCE = os.path.dirname(source_path)
     else:
+        entries = MAPPING_LIST.get_entries()
+        if entries:
+            entry = entries[0]
+            entry.source_path = None
+            entry.source_face = None
+            entry.source_cv2 = None
         modules.globals.source_path = None
-        source_label.configure(image=None)
 
 
 def swap_faces_paths() -> None:
@@ -970,16 +1016,27 @@ def swap_faces_paths() -> None:
     if not is_image(source_path) or not is_image(target_path):
         return
 
-    modules.globals.source_path = target_path
-    modules.globals.target_path = source_path
+    # Swap: old target becomes new source (first mapping), old source becomes new target
+    new_source_path = target_path
+    new_target_path = source_path
 
-    RECENT_DIRECTORY_SOURCE = os.path.dirname(modules.globals.source_path)
-    RECENT_DIRECTORY_TARGET = os.path.dirname(modules.globals.target_path)
+    # Update target global
+    modules.globals.target_path = new_target_path
+    RECENT_DIRECTORY_TARGET = os.path.dirname(new_target_path)
+
+    # Update source via MAPPING_LIST (triggers observer → syncs globals)
+    cv2_img = cv2.imread(new_source_path)
+    if cv2_img is not None:
+        face = get_one_face(cv2_img)
+        if face is not None:
+            x_min, y_min, x_max, y_max = face["bbox"]
+            cropped = cv2_img[int(y_min):int(y_max), int(x_min):int(x_max)]
+            entries = MAPPING_LIST.get_entries()
+            entry_id = entries[0].id if entries else 0
+            MAPPING_LIST.set_source(entry_id, new_source_path, cropped, face)
+            RECENT_DIRECTORY_SOURCE = os.path.dirname(new_source_path)
 
     PREVIEW.withdraw()
-
-    source_image = render_image_preview(modules.globals.source_path, SIDEBAR_THUMB_SIZE)
-    source_label.configure(image=source_image)
 
     target_image = render_image_preview(modules.globals.target_path, SIDEBAR_THUMB_SIZE)
     target_label.configure(image=target_image)

--- a/modules/ui_analysis.py
+++ b/modules/ui_analysis.py
@@ -14,12 +14,13 @@ def analyze_target(start, root):
         get_unique_faces_from_target_image,
         get_unique_faces_from_target_video,
     )
+    from modules.mapping_list import MAPPING_LIST
 
     if POPUP is not None and POPUP.winfo_exists():
         update_status("Please complete pop-up or close it.")
         return
 
-    if modules.globals.map_faces:
+    if MAPPING_LIST.effective_map_faces():
         from modules.face_map_store import STORE as _MAP_STORE
         _MAP_STORE.clear()
 

--- a/modules/ui_mapping_list.py
+++ b/modules/ui_mapping_list.py
@@ -1,0 +1,205 @@
+"""Inline mapping list widget for the sidebar (Unified Face Mapping UI).
+
+Renders a scrollable list of source→pin mapping entries.  Single-mapping
+mode shows 120x120 thumbnails (matching current UI).  Multi-mapping mode
+uses 80x80 thumbnails with row labels.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+import cv2
+import customtkinter as ctk
+from PIL import Image, ImageOps
+
+from modules.mapping_list import MappingList
+
+
+# Thumbnail sizes
+_SINGLE_THUMB = (120, 120)
+_MULTI_THUMB = (80, 80)
+
+
+class MappingListWidget:
+    """Renders and manages the mapping list in the sidebar.
+
+    Subscribes to ``mapping_list.on_change`` so any mutation triggers a
+    rebuild of the widget tree.  All widget updates are on the main thread.
+    """
+
+    def __init__(
+        self,
+        parent: ctk.CTkFrame,
+        mapping_list: MappingList,
+        on_change_callback: Callable[[], None] | None = None,
+    ) -> None:
+        self._parent = parent
+        self._mapping_list = mapping_list
+        self._on_change_cb = on_change_callback
+        self._frame: ctk.CTkFrame | None = None
+        self._mapping_list.on_change(self._rebuild)
+        self._rebuild()
+
+    # ------------------------------------------------------------------
+    # Public helpers (used by tests and host code)
+    # ------------------------------------------------------------------
+
+    def _should_show_remove(self) -> bool:
+        return len(self._mapping_list.get_entries()) > 1
+
+    def _thumb_size(self) -> tuple[int, int]:
+        if len(self._mapping_list.get_entries()) > 1:
+            return _MULTI_THUMB
+        return _SINGLE_THUMB
+
+    # ------------------------------------------------------------------
+    # Widget construction
+    # ------------------------------------------------------------------
+
+    def _rebuild(self) -> None:
+        """Destroy and recreate the widget tree from current MappingList state."""
+        if self._frame is not None:
+            self._frame.destroy()
+
+        self._frame = ctk.CTkFrame(self._parent, fg_color="transparent")
+        self._frame.pack(fill="both", expand=True)
+        self._frame.columnconfigure(0, weight=1)
+
+        entries = self._mapping_list.get_entries()
+        thumb = self._thumb_size()
+        show_remove = self._should_show_remove()
+
+        for row_idx, entry in enumerate(entries):
+            self._build_entry_row(self._frame, entry, row_idx, thumb, show_remove)
+
+        # "+ Add mapping" button
+        add_btn = ctk.CTkButton(
+            self._frame,
+            text="+ Add mapping",
+            cursor="hand2",
+            command=self._on_add,
+            height=28,
+        )
+        add_btn.grid(
+            row=len(entries), column=0, pady=(5, 0), sticky="ew", padx=5,
+        )
+
+    def _build_entry_row(
+        self,
+        parent: ctk.CTkFrame,
+        entry,
+        row: int,
+        thumb: tuple[int, int],
+        show_remove: bool,
+    ) -> None:
+        row_frame = ctk.CTkFrame(parent, fg_color="transparent")
+        row_frame.grid(row=row, column=0, sticky="ew", padx=2, pady=2)
+        row_frame.columnconfigure(0, weight=1)
+
+        # Header with optional remove button
+        if show_remove:
+            header = ctk.CTkFrame(row_frame, fg_color="transparent")
+            header.grid(row=0, column=0, sticky="ew")
+            header.columnconfigure(0, weight=1)
+            ctk.CTkLabel(header, text=f"Mapping {entry.id + 1}", anchor="w").grid(
+                row=0, column=0, sticky="w", padx=5,
+            )
+            remove_btn = ctk.CTkButton(
+                header, text="\u00d7", width=24, height=24, cursor="hand2",
+                command=lambda eid=entry.id: self._on_remove(eid),
+            )
+            remove_btn.grid(row=0, column=1, padx=2)
+
+        # Source thumbnail
+        src_label = ctk.CTkLabel(row_frame, text=None, width=thumb[0], height=thumb[1])
+        src_label.grid(row=1, column=0, pady=(2, 2))
+        if entry.source_cv2 is not None:
+            self._set_thumbnail(src_label, entry.source_cv2, thumb)
+
+        # Select face button
+        select_btn = ctk.CTkButton(
+            row_frame, text="Select a face", cursor="hand2",
+            command=lambda eid=entry.id: self._on_select_source(eid),
+        )
+        select_btn.grid(row=2, column=0, sticky="ew", padx=5, pady=(0, 2))
+
+        # Pin section (optional target reference)
+        if entry.pin_cv2 is not None:
+            pin_label = ctk.CTkLabel(row_frame, text=None, width=thumb[0], height=thumb[1])
+            pin_label.grid(row=3, column=0, pady=(2, 2))
+            self._set_thumbnail(pin_label, entry.pin_cv2, thumb)
+
+        pin_btn = ctk.CTkButton(
+            row_frame, text="Pin to face", cursor="hand2", height=24,
+            command=lambda eid=entry.id: self._on_select_pin(eid),
+        )
+        pin_btn.grid(row=4, column=0, sticky="ew", padx=5, pady=(0, 2))
+
+        # Separator (if multi)
+        if show_remove:
+            sep = ctk.CTkFrame(row_frame, height=1, fg_color="gray50")
+            sep.grid(row=5, column=0, sticky="ew", padx=10, pady=4)
+
+    @staticmethod
+    def _set_thumbnail(
+        label: ctk.CTkLabel, cv2_img, size: tuple[int, int],
+    ) -> None:
+        """Set a CTkImage on a label from a BGR cv2 image."""
+        rgb = cv2.cvtColor(cv2_img, cv2.COLOR_BGR2RGB)
+        image = Image.fromarray(rgb)
+        image = ImageOps.fit(image, size, Image.LANCZOS)
+        ctk_img = ctk.CTkImage(image, size=size)
+        label.configure(image=ctk_img)
+        # Keep reference to prevent GC
+        label._ctk_img = ctk_img
+
+    # ------------------------------------------------------------------
+    # Button handlers
+    # ------------------------------------------------------------------
+
+    def _on_add(self) -> None:
+        self._mapping_list.add_entry()
+
+    def _on_remove(self, entry_id: int) -> None:
+        self._mapping_list.remove_entry(entry_id)
+
+    def _on_select_source(self, entry_id: int) -> None:
+        """Open file dialog and set source face for the given entry."""
+        from modules.face_analyser import get_one_face
+
+        path = ctk.filedialog.askopenfilename(
+            title="Select a source face image",
+            filetypes=[("Image", "*.png *.jpg *.jpeg *.gif *.bmp")],
+        )
+        if not path:
+            return
+        img = cv2.imread(path)
+        if img is None:
+            return
+        face = get_one_face(img)
+        if face is None:
+            return
+        # Crop face region for thumbnail
+        x_min, y_min, x_max, y_max = face["bbox"]
+        cropped = img[int(y_min):int(y_max), int(x_min):int(x_max)]
+        self._mapping_list.set_source(entry_id, path, cropped, face)
+
+    def _on_select_pin(self, entry_id: int) -> None:
+        """Open file dialog and set pin face for the given entry."""
+        from modules.face_analyser import get_one_face
+
+        path = ctk.filedialog.askopenfilename(
+            title="Select a target reference face image",
+            filetypes=[("Image", "*.png *.jpg *.jpeg *.gif *.bmp")],
+        )
+        if not path:
+            return
+        img = cv2.imread(path)
+        if img is None:
+            return
+        face = get_one_face(img)
+        if face is None:
+            return
+        x_min, y_min, x_max, y_max = face["bbox"]
+        cropped = img[int(y_min):int(y_max), int(x_min):int(x_max)]
+        self._mapping_list.set_pin(entry_id, path, cropped, face)

--- a/modules/ui_webcam.py
+++ b/modules/ui_webcam.py
@@ -111,7 +111,7 @@ def _swap_process_fn(inp):
     processor = inp['processor']
 
     if inp['map_faces']:
-        frame = processor.process_frame(None, frame)
+        frame = processor.process_frame_v2(frame)
     else:
         source_face = inp['source_face']
         many_faces_list = inp['many_faces']
@@ -664,7 +664,8 @@ def create_webcam_preview(camera_index: int, config: Optional[ProcessingConfig] 
 
 def webcam_preview(root: ctk.CTk, camera_index: int, config: Optional[ProcessingConfig] = None):
     from modules.ui import POPUP_LIVE, update_status
-    from modules.ui_mapper import create_source_target_popup_for_webcam
+    from modules.mapping_list import MAPPING_LIST
+    from modules.face_map_store import STORE as _MAP_STORE
 
     if config is None:
         config = build_config_from_globals()
@@ -674,14 +675,19 @@ def webcam_preview(root: ctk.CTk, camera_index: int, config: Optional[Processing
         POPUP_LIVE.focus()
         return
 
-    if not config.map_faces:
-        if config.source_path is None:
+    effective_map = MAPPING_LIST.effective_map_faces()
+
+    if not effective_map:
+        # Single source, no pins — simple face swap mode
+        if MAPPING_LIST.source_count() == 0:
             update_status("Please select a source image first")
             return
+        # Sync mapping list to store for consistency
+        MAPPING_LIST.sync_to_store(_MAP_STORE)
         create_webcam_preview(camera_index, config=config)
     else:
-        from modules.face_map_store import STORE as _MAP_STORE
-        _MAP_STORE.clear()
-        create_source_target_popup_for_webcam(
-            root, _MAP_STORE.get_entries(), camera_index
-        )
+        # Multiple sources or pins — map faces mode
+        MAPPING_LIST.sync_to_store(_MAP_STORE)
+        if _MAP_STORE.has_valid_map():
+            _MAP_STORE.simplify()
+        create_webcam_preview(camera_index, config=config)

--- a/tests/test_mapping_list.py
+++ b/tests/test_mapping_list.py
@@ -1,0 +1,358 @@
+"""Tests for the MappingList data model (Phase 1 — Unified Face Mapping UI)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock
+
+from modules.mapping_list import MappingEntry, MappingList
+
+
+# ---------------------------------------------------------------------------
+# MappingEntry basics
+# ---------------------------------------------------------------------------
+
+class TestMappingEntry:
+    def test_default_fields(self):
+        entry = MappingEntry(id=0)
+        assert entry.id == 0
+        assert entry.source_path is None
+        assert entry.source_face is None
+        assert entry.source_cv2 is None
+        assert entry.pin_path is None
+        assert entry.pin_face is None
+        assert entry.pin_cv2 is None
+
+    def test_with_source(self):
+        face = MagicMock()
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        entry = MappingEntry(id=1, source_path="/a.png", source_face=face, source_cv2=img)
+        assert entry.source_path == "/a.png"
+        assert entry.source_face is face
+        assert entry.source_cv2 is img
+
+    def test_with_pin(self):
+        face = MagicMock()
+        img = np.zeros((80, 80, 3), dtype=np.uint8)
+        entry = MappingEntry(id=2, pin_path="/b.png", pin_face=face, pin_cv2=img)
+        assert entry.pin_path == "/b.png"
+        assert entry.pin_face is face
+
+
+# ---------------------------------------------------------------------------
+# MappingList — add / remove / get
+# ---------------------------------------------------------------------------
+
+class TestMappingListBasics:
+    def test_starts_with_one_entry(self):
+        ml = MappingList()
+        assert len(ml.get_entries()) == 1
+        assert ml.get_entries()[0].id == 0
+
+    def test_add_entry(self):
+        ml = MappingList()
+        entry = ml.add_entry()
+        assert entry.id == 1
+        assert len(ml.get_entries()) == 2
+
+    def test_add_multiple_entries(self):
+        ml = MappingList()
+        ml.add_entry()
+        ml.add_entry()
+        entries = ml.get_entries()
+        assert len(entries) == 3
+        assert [e.id for e in entries] == [0, 1, 2]
+
+    def test_remove_entry(self):
+        ml = MappingList()
+        ml.add_entry()
+        ml.remove_entry(0)
+        entries = ml.get_entries()
+        assert len(entries) == 1
+        assert entries[0].id == 1
+
+    def test_remove_nonexistent_entry(self):
+        ml = MappingList()
+        ml.remove_entry(999)  # should not raise
+        assert len(ml.get_entries()) == 1
+
+    def test_remove_last_entry_leaves_empty(self):
+        ml = MappingList()
+        ml.remove_entry(0)
+        assert len(ml.get_entries()) == 0
+
+    def test_clear_all(self):
+        ml = MappingList()
+        ml.add_entry()
+        ml.add_entry()
+        ml.clear_all()
+        assert len(ml.get_entries()) == 0
+
+    def test_get_entries_returns_snapshot(self):
+        ml = MappingList()
+        entries = ml.get_entries()
+        entries.append(MappingEntry(id=99))
+        assert len(ml.get_entries()) == 1  # original unaffected
+
+
+# ---------------------------------------------------------------------------
+# MappingList — set_source / set_pin / clear_pin
+# ---------------------------------------------------------------------------
+
+class TestMappingListSourcePin:
+    def test_set_source(self):
+        ml = MappingList()
+        face = MagicMock()
+        img = np.zeros((50, 50, 3), dtype=np.uint8)
+        ml.set_source(0, "/src.png", img, face)
+        entry = ml.get_entries()[0]
+        assert entry.source_path == "/src.png"
+        assert entry.source_face is face
+        assert entry.source_cv2 is img
+
+    def test_set_source_nonexistent_id(self):
+        ml = MappingList()
+        ml.set_source(999, "/x.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        # no crash, entry 0 unchanged
+        assert ml.get_entries()[0].source_path is None
+
+    def test_set_pin(self):
+        ml = MappingList()
+        face = MagicMock()
+        img = np.zeros((50, 50, 3), dtype=np.uint8)
+        ml.set_pin(0, "/pin.png", img, face)
+        entry = ml.get_entries()[0]
+        assert entry.pin_path == "/pin.png"
+        assert entry.pin_face is face
+        assert entry.pin_cv2 is img
+
+    def test_clear_pin(self):
+        ml = MappingList()
+        ml.set_pin(0, "/pin.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        ml.clear_pin(0)
+        entry = ml.get_entries()[0]
+        assert entry.pin_path is None
+        assert entry.pin_face is None
+        assert entry.pin_cv2 is None
+
+
+# ---------------------------------------------------------------------------
+# Derived state
+# ---------------------------------------------------------------------------
+
+class TestDerivedState:
+    def test_effective_map_faces_single_no_pin(self):
+        ml = MappingList()
+        assert ml.effective_map_faces() is False
+
+    def test_effective_map_faces_multiple_entries(self):
+        ml = MappingList()
+        ml.add_entry()
+        assert ml.effective_map_faces() is True
+
+    def test_effective_map_faces_with_pin(self):
+        ml = MappingList()
+        ml.set_pin(0, "/pin.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        assert ml.effective_map_faces() is True
+
+    def test_effective_source_path_none(self):
+        ml = MappingList()
+        assert ml.effective_source_path() is None
+
+    def test_effective_source_path_set(self):
+        ml = MappingList()
+        ml.set_source(0, "/src.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        assert ml.effective_source_path() == "/src.png"
+
+    def test_source_count_zero(self):
+        ml = MappingList()
+        assert ml.source_count() == 0
+
+    def test_source_count_with_sources(self):
+        ml = MappingList()
+        ml.set_source(0, "/a.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        ml.add_entry()
+        assert ml.source_count() == 1
+        ml.set_source(1, "/b.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        assert ml.source_count() == 2
+
+
+# ---------------------------------------------------------------------------
+# On-change callbacks
+# ---------------------------------------------------------------------------
+
+class TestOnChangeCallbacks:
+    def test_add_triggers_callback(self):
+        cb = MagicMock()
+        ml = MappingList()
+        ml.on_change(cb)
+        ml.add_entry()
+        cb.assert_called_once()
+
+    def test_remove_triggers_callback(self):
+        cb = MagicMock()
+        ml = MappingList()
+        ml.on_change(cb)
+        ml.remove_entry(0)
+        cb.assert_called_once()
+
+    def test_set_source_triggers_callback(self):
+        cb = MagicMock()
+        ml = MappingList()
+        ml.on_change(cb)
+        ml.set_source(0, "/s.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        cb.assert_called_once()
+
+    def test_set_pin_triggers_callback(self):
+        cb = MagicMock()
+        ml = MappingList()
+        ml.on_change(cb)
+        ml.set_pin(0, "/p.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        cb.assert_called_once()
+
+    def test_clear_all_triggers_callback(self):
+        cb = MagicMock()
+        ml = MappingList()
+        ml.on_change(cb)
+        ml.clear_all()
+        cb.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Sync to FaceMapStore
+# ---------------------------------------------------------------------------
+
+class TestSyncToStore:
+    def test_sync_single_source_no_pin(self):
+        """Single source with no pin should set entries but not simplify."""
+        from modules.face_map_store import FaceMapStore
+        store = FaceMapStore()
+        ml = MappingList()
+        face = MagicMock()
+        img = np.zeros((50, 50, 3), dtype=np.uint8)
+        ml.set_source(0, "/src.png", img, face)
+        ml.sync_to_store(store)
+        entries = store.get_entries()
+        assert len(entries) == 1
+        assert entries[0]['source']['face'] is face
+        assert entries[0]['source']['cv2'] is img
+
+    def test_sync_with_pin_calls_simplify(self):
+        """Entries with pins should have both source and target, and simplify is called."""
+        from modules.face_map_store import FaceMapStore
+        store = FaceMapStore()
+        ml = MappingList()
+        src_face = MagicMock()
+        src_face.normed_embedding = np.ones(512)
+        pin_face = MagicMock()
+        pin_face.normed_embedding = np.ones(512)
+        src_img = np.zeros((50, 50, 3), dtype=np.uint8)
+        pin_img = np.zeros((50, 50, 3), dtype=np.uint8)
+        ml.set_source(0, "/src.png", src_img, src_face)
+        ml.set_pin(0, "/pin.png", pin_img, pin_face)
+        ml.sync_to_store(store)
+        entries = store.get_entries()
+        assert len(entries) == 1
+        assert 'source' in entries[0]
+        assert 'target' in entries[0]
+        # simplify should have been called — check simple map
+        simple = store.get_simple_map()
+        assert len(simple.get('source_faces', [])) == 1
+
+    def test_sync_skips_entries_without_source(self):
+        from modules.face_map_store import FaceMapStore
+        store = FaceMapStore()
+        ml = MappingList()
+        ml.add_entry()  # entry 1 — no source
+        ml.sync_to_store(store)
+        assert len(store.get_entries()) == 0
+
+    def test_sync_multiple_sources(self):
+        from modules.face_map_store import FaceMapStore
+        store = FaceMapStore()
+        ml = MappingList()
+        for i in range(2):
+            if i > 0:
+                ml.add_entry()
+            face = MagicMock()
+            face.normed_embedding = np.ones(512)
+            ml.set_source(i, f"/{i}.png", np.zeros((10, 10, 3), dtype=np.uint8), face)
+        ml.sync_to_store(store)
+        assert len(store.get_entries()) == 2
+
+
+# ---------------------------------------------------------------------------
+# Persistence (to_dict / restore_from_dict)
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def test_round_trip_empty(self):
+        ml = MappingList()
+        data = ml.to_dict()
+        ml2 = MappingList()
+        ml2.clear_all()
+        ml2.restore_from_dict(data)
+        assert len(ml2.get_entries()) == 1
+
+    def test_round_trip_with_source(self):
+        ml = MappingList()
+        ml.set_source(0, "/src.png", np.zeros((10, 10, 3), dtype=np.uint8), MagicMock())
+        data = ml.to_dict()
+        ml2 = MappingList()
+        ml2.clear_all()
+        ml2.restore_from_dict(data)
+        entries = ml2.get_entries()
+        assert len(entries) == 1
+        assert entries[0].source_path == "/src.png"
+        # face objects are not serialized
+        assert entries[0].source_face is None
+
+    def test_round_trip_with_pin(self):
+        ml = MappingList()
+        ml.set_pin(0, "/pin.png", np.zeros((10, 10, 3), dtype=np.uint8), MagicMock())
+        data = ml.to_dict()
+        ml2 = MappingList()
+        ml2.clear_all()
+        ml2.restore_from_dict(data)
+        entries = ml2.get_entries()
+        assert entries[0].pin_path == "/pin.png"
+        assert entries[0].pin_face is None
+
+    def test_round_trip_multiple_entries(self):
+        ml = MappingList()
+        ml.set_source(0, "/a.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        ml.add_entry()
+        ml.set_source(1, "/b.png", np.zeros((1, 1, 3), dtype=np.uint8), MagicMock())
+        data = ml.to_dict()
+        ml2 = MappingList()
+        ml2.clear_all()
+        ml2.restore_from_dict(data)
+        entries = ml2.get_entries()
+        assert len(entries) == 2
+        assert entries[0].source_path == "/a.png"
+        assert entries[1].source_path == "/b.png"
+
+    def test_to_dict_excludes_cv2_and_face(self):
+        ml = MappingList()
+        ml.set_source(0, "/src.png", np.zeros((10, 10, 3), dtype=np.uint8), MagicMock())
+        data = ml.to_dict()
+        entry = data[0]
+        assert "source_cv2" not in entry
+        assert "source_face" not in entry
+        assert "pin_cv2" not in entry
+        assert "pin_face" not in entry
+
+    def test_restore_from_empty_list(self):
+        ml = MappingList()
+        ml.restore_from_dict([])
+        # Should have no entries
+        assert len(ml.get_entries()) == 0
+
+    def test_migrate_from_source_path(self):
+        """Old state file has source_path but no mappings key — should create single mapping."""
+        ml = MappingList()
+        ml.clear_all()
+        ml.restore_from_source_path("/legacy.png")
+        entries = ml.get_entries()
+        assert len(entries) == 1
+        assert entries[0].source_path == "/legacy.png"

--- a/tests/test_mapping_list_widget.py
+++ b/tests/test_mapping_list_widget.py
@@ -1,0 +1,107 @@
+"""Tests for MappingListWidget (Phase 2 — Unified Face Mapping UI).
+
+These tests verify the widget logic without requiring a live Tkinter display.
+We mock CTk widgets so tests run in CI without a GUI.
+"""
+from __future__ import annotations
+
+import numpy as np
+from unittest.mock import MagicMock, patch
+
+from modules.mapping_list import MappingList, MappingEntry
+
+
+# ---------------------------------------------------------------------------
+# We cannot import the widget module at module level because it imports CTk.
+# Instead, we patch customtkinter before importing.
+# ---------------------------------------------------------------------------
+
+def _import_widget_module():
+    """Import ui_mapping_list with CTk mocked out for headless testing."""
+    # The module imports customtkinter at the top level; we need it available
+    # but don't need a real Tk instance.
+    import modules.ui_mapping_list as mod
+    return mod
+
+
+class TestMappingListWidgetCreation:
+    """Test that the widget initialises from MappingList state."""
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_widget_constructs_without_error(self, mock_ctk):
+        mod = _import_widget_module()
+        ml = MappingList()
+        parent = MagicMock()
+        widget = mod.MappingListWidget(parent, ml)
+        assert widget is not None
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_widget_subscribes_to_changes(self, mock_ctk):
+        """Widget registers an on_change callback during construction."""
+        mod = _import_widget_module()
+        ml = MappingList()
+        parent = MagicMock()
+        initial_cb_count = len(ml._on_change)
+        mod.MappingListWidget(parent, ml)
+        assert len(ml._on_change) == initial_cb_count + 1
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_remove_button_hidden_for_single_entry(self, mock_ctk):
+        mod = _import_widget_module()
+        ml = MappingList()
+        parent = MagicMock()
+        widget = mod.MappingListWidget(parent, ml)
+        # Single entry — remove button should not be shown
+        assert widget._should_show_remove() is False
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_remove_button_shown_for_multiple_entries(self, mock_ctk):
+        mod = _import_widget_module()
+        ml = MappingList()
+        ml.add_entry()
+        parent = MagicMock()
+        widget = mod.MappingListWidget(parent, ml)
+        assert widget._should_show_remove() is True
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_thumb_size_single_entry(self, mock_ctk):
+        mod = _import_widget_module()
+        ml = MappingList()
+        parent = MagicMock()
+        widget = mod.MappingListWidget(parent, ml)
+        assert widget._thumb_size() == (120, 120)
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_thumb_size_multiple_entries(self, mock_ctk):
+        mod = _import_widget_module()
+        ml = MappingList()
+        ml.add_entry()
+        parent = MagicMock()
+        widget = mod.MappingListWidget(parent, ml)
+        assert widget._thumb_size() == (80, 80)
+
+
+class TestMappingListWidgetCallbacks:
+    """Test that widget button handlers call the right MappingList methods."""
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_on_add_calls_add_entry(self, mock_ctk):
+        mod = _import_widget_module()
+        ml = MappingList()
+        parent = MagicMock()
+        widget = mod.MappingListWidget(parent, ml)
+        initial_count = len(ml.get_entries())
+        widget._on_add()
+        assert len(ml.get_entries()) == initial_count + 1
+
+    @patch("modules.ui_mapping_list.ctk")
+    def test_on_remove_calls_remove_entry(self, mock_ctk):
+        mod = _import_widget_module()
+        ml = MappingList()
+        ml.add_entry()
+        parent = MagicMock()
+        widget = mod.MappingListWidget(parent, ml)
+        widget._on_remove(0)
+        entries = ml.get_entries()
+        assert len(entries) == 1
+        assert entries[0].id == 1


### PR DESCRIPTION
## Summary

- Replace the separate source selector + Map Faces toggle with an inline mapping list in the sidebar
- Single mapping looks like the current UI; adding mappings extends naturally for multi-face workflows
- New `MappingList` data model with change callbacks, FaceMapStore sync, and persistence
- New `MappingListWidget` renders mappings inline with add/remove/select-source/pin-to-face controls
- Fix `process_frame` → `process_frame_v2` bug in map_faces swap path
- 46 new tests, all 620 existing tests pass

## How it works

| Scenario | Behavior |
|----------|----------|
| 1 mapping, no pin | Current "face swap" behavior |
| 1 mapping + Swap All | Current "many faces" behavior |
| N mappings, no pins | Sources matched to detected faces by embedding distance |
| N mappings + pins | Sources matched to specific pinned target faces |

## Files changed

| File | Change |
|------|--------|
| `modules/mapping_list.py` | **New** — MappingEntry + MappingList data model |
| `modules/ui_mapping_list.py` | **New** — MappingListWidget (CTk frame) |
| `modules/ui.py` | Replace source column, remove Map Faces toggle, wire observer, update persistence |
| `modules/ui_webcam.py` | Use MappingList state, fix process_frame_v2 bug |
| `modules/ui_analysis.py` | Use MappingList.effective_map_faces() |

## Backward compatibility

- CLI/headless unchanged (`--source`, `--map-faces` flags still work)
- Old `switch_states.json` auto-migrates from legacy `source_path` format
- `modules.globals.source_path` and `map_faces` kept in sync by observer

## Follow-up

- #75 — Split live cam and file processing into separate UI modes

## Test plan

- [ ] Single mapping: select source → Start/Live → swaps work as before
- [ ] Multiple mappings: add 2+ sources → Live → faces matched by embedding distance
- [ ] Pinned targets: pin a mapping → Live → source swaps onto pinned face
- [ ] Swap All + single mapping: toggle on → all detected faces get same source
- [ ] State persistence: close app → reopen → mappings restored
- [ ] Existing test suite: `pytest` passes (620 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)