### PR TITLE
feat: add occlusion mask UI toggle and fix auto-download on first use

### DIFF
--- a/modules/face_occluder.py
+++ b/modules/face_occluder.py
@@ -47,8 +47,9 @@ def get_face_occluder(providers: list | None = None) -> onnxruntime.InferenceSes
                 providers_config = build_providers_config(_providers)
                 model_path = os.path.join(MODELS_DIR, _XSEG_MODEL['file'])
                 if not os.path.exists(model_path):
-                    update_status(f"XSeg model not found: {model_path}", NAME)
-                    return None
+                    update_status("XSeg model not found — downloading now...", NAME)
+                    if not pre_check():
+                        return None
                 try:
                     FACE_OCCLUDER = onnxruntime.InferenceSession(
                         model_path, providers=providers_config,

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -198,6 +198,7 @@ def save_switch_states():
         "virtual_cam": modules.globals.virtual_cam,
         "mouth_mask": modules.globals.mouth_mask,
         "show_mouth_mask_box": modules.globals.show_mouth_mask_box,
+        "occlusion_mask": modules.globals.occlusion_mask,
         "rife_enabled": modules.globals.rife_enabled,
         "rife_model": modules.globals.rife_model,
         "rife_multiplier": modules.globals.rife_multiplier,
@@ -238,6 +239,7 @@ def load_switch_states():
         modules.globals.show_mouth_mask_box = switch_states.get(
             "show_mouth_mask_box", False
         )
+        modules.globals.occlusion_mask = switch_states.get("occlusion_mask", False)
         modules.globals.rife_enabled = switch_states.get("rife_enabled", False)
         modules.globals.rife_model = switch_states.get("rife_model", "rife-v4.25-lite")
         modules.globals.rife_multiplier = switch_states.get("rife_multiplier", 2)
@@ -440,6 +442,8 @@ def _get_switch_defs():
              _("Preserve original mouth movement in the swapped face")),
             (_("Show Mask Outline"), "show_mouth_mask_box", False,
              _("Display the mouth mask boundary for debugging")),
+            (_("Occlusion Mask"), "occlusion_mask", False,
+             _("Preserve hands, glasses, and other objects covering the face during swap")),
             (_("Swap All Faces"), "many_faces", False,
              _("Swap every detected face, not just the primary one")),
             (_("Seamless Blend"), "poisson_blend", False,

--- a/tests/test_face_occluder.py
+++ b/tests/test_face_occluder.py
@@ -113,13 +113,14 @@ class TestFaceOccluderSingleton:
         assert call_count == 1, f"Expected 1 session creation, got {call_count}"
 
     def test_get_face_occluder_returns_none_when_model_missing(self):
-        """Returns None when model file does not exist."""
+        """Returns None when model file does not exist and download fails."""
         from modules import face_occluder
 
         original = face_occluder.FACE_OCCLUDER
         face_occluder.FACE_OCCLUDER = None
         try:
-            with patch('modules.face_occluder.os.path.exists', return_value=False):
+            with patch('modules.face_occluder.os.path.exists', return_value=False), \
+                 patch('modules.face_occluder.pre_check', return_value=False):
                 result = face_occluder.get_face_occluder(
                     providers=['CPUExecutionProvider']
                 )


### PR DESCRIPTION
Adds a UI toggle for the occlusion mask feature and fixes auto-download when toggled on mid-session.

- "Occlusion Mask" switch in Processing tab (next to Mouth Mask)
- State persisted across restarts
- Auto-downloads xseg_2.onnx in background on first enable

Related to #84

Generated with [Claude Code](https://claude.ai/code)