### PR TITLE
fix: add missing codeformer key and misc code quality fixes

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -47,8 +47,8 @@ def _ensure_torch() -> bool:
 def parse_args() -> None:
     signal.signal(signal.SIGINT, lambda signal_number, frame: destroy())
     program = argparse.ArgumentParser()
-    program.add_argument('-s', '--source', help='select an source image', dest='source_path')
-    program.add_argument('-t', '--target', help='select an target image or video', dest='target_path')
+    program.add_argument('-s', '--source', help='select a source image', dest='source_path')
+    program.add_argument('-t', '--target', help='select a target image or video', dest='target_path')
     program.add_argument('-o', '--output', help='select output file or directory', dest='output_path')
     program.add_argument('--frame-processor', help='pipeline of frame processors', dest='frame_processor', default=['face_swapper'], choices=['face_swapper', 'face_enhancer', 'face_enhancer_gpen256', 'face_enhancer_gpen512', 'face_enhancer_codeformer'], nargs='+')
     program.add_argument('--png-frames', help='use lossless PNG for intermediate frames (larger files, no artifacts)', dest='use_png_frames', action='store_true', default=False)
@@ -124,7 +124,6 @@ def parse_args() -> None:
     modules.globals.live_enhance_size = args.live_enhance_size
     modules.globals.landmark_smoothing = args.landmark_smoothing
     modules.globals.landmark_smoothing_alpha = max(0.0, min(1.0, args.landmark_smoothing_alpha))
-    modules.globals.face_swap_model = args.face_swap_model
 
     #for ENHANCER tumblers:
     for enhancer_key in ('face_enhancer', 'face_enhancer_gpen256', 'face_enhancer_gpen512', 'face_enhancer_codeformer'):

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -22,7 +22,6 @@ from modules.utilities import (
     is_image,
     is_video,
 )
-from modules.onnx_providers import build_providers_config
 from modules.processing_config import ProcessingConfig
 from modules.processing_config_factory import build_config_from_globals
 from modules.face_preprocessing import (

--- a/modules/ui_webcam.py
+++ b/modules/ui_webcam.py
@@ -38,6 +38,7 @@ _ENHANCER_NAMES = frozenset({
     "DLC.FACE-ENHANCER",
     "DLC.FACE-ENHANCER-GPEN256",
     "DLC.FACE-ENHANCER-GPEN512",
+    "DLC.FACE-ENHANCER-CODEFORMER",
 })
 
 # Map from processor NAME to fp_ui toggle key
@@ -45,6 +46,7 @@ _ENHANCER_UI_KEYS = {
     "DLC.FACE-ENHANCER": "face_enhancer",
     "DLC.FACE-ENHANCER-GPEN256": "face_enhancer_gpen256",
     "DLC.FACE-ENHANCER-GPEN512": "face_enhancer_gpen512",
+    "DLC.FACE-ENHANCER-CODEFORMER": "face_enhancer_codeformer",
 }
 
 
@@ -72,8 +74,6 @@ def stop_active_session(timeout: float = 0.5) -> None:
     # if cleanup doesn't run (e.g., ROOT.quit() stopped the display loop),
     # the wait just times out — which is still enough grace time.
     _session_ready.wait(timeout=timeout)
-
-
 def _capture_thread_func(cap, capture_queue, stop_event):
     """Capture thread: reads frames from camera and puts them into the queue.
     Drops frames when the queue is full to avoid backpressure on the camera."""
@@ -595,8 +595,7 @@ def create_webcam_preview(camera_index: int, config: Optional[ProcessingConfig] 
         config = build_config_from_globals()
 
     # If a session is already running, stop it and defer start until cleanup finishes.
-    if _active_stop_event is not None and not _active_stop_event.is_set():
-        _active_stop_event.set()
+    stop_active_session()
 
     if not _session_ready.is_set():
         def _retry():

--- a/tests/test_stop_active_session.py
+++ b/tests/test_stop_active_session.py
@@ -1,0 +1,43 @@
+"""Tests for stop_active_session() in ui_webcam."""
+
+import threading
+
+import pytest
+
+from modules.ui_webcam import stop_active_session, _session_ready
+
+
+class TestStopActiveSession:
+    """Verify stop_active_session signals the active session to stop."""
+
+    def setup_method(self):
+        """Reset module-level session state before each test."""
+        import modules.ui_webcam as uw
+        uw._active_stop_event = None
+        uw._session_ready.set()
+
+    def test_noop_when_no_session_running(self):
+        """Calling stop when no session is active should be a safe no-op."""
+        import modules.ui_webcam as uw
+        assert uw._active_stop_event is None
+        stop_active_session()
+        # Should not raise, _active_stop_event stays None
+        assert uw._active_stop_event is None
+
+    def test_sets_stop_event_when_session_active(self):
+        """An active session's stop event should be set."""
+        import modules.ui_webcam as uw
+        evt = threading.Event()
+        uw._active_stop_event = evt
+        assert not evt.is_set()
+        stop_active_session()
+        assert evt.is_set()
+
+    def test_noop_when_stop_event_already_set(self):
+        """Calling stop when the session was already stopping is a safe no-op."""
+        import modules.ui_webcam as uw
+        evt = threading.Event()
+        evt.set()
+        uw._active_stop_event = evt
+        stop_active_session()
+        assert evt.is_set()


### PR DESCRIPTION
## Summary

Closes #100

- Add `DLC.FACE-ENHANCER-CODEFORMER` to `_ENHANCER_NAMES` and `_ENHANCER_UI_KEYS` in `ui_webcam.py` — codeformer was never recognized for skip-frame logic
- Remove duplicate `face_swap_model` assignment in `core.py` (copy-paste drift at lines 114/127)
- Fix "an source"/"an target" → "a source"/"a target" typos in CLI help text
- Remove duplicate `build_providers_config` import in `face_enhancer.py`
- Extract `stop_active_session()` from inline logic in `create_webcam_preview()` with 3 unit tests

## Test plan

- [x] 3 new tests for `stop_active_session()` pass
- [x] Existing face_enhancer and processing_config tests pass (20/20)
- [ ] Manual: verify codeformer enhancer works in live webcam mode with skip-frame logic
- [ ] Manual: verify `--help` shows corrected help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)