### PR TITLE
fix: resolve E731 and SIM108 lint warnings

### DIFF
--- a/modules/paste_back.py
+++ b/modules/paste_back.py
@@ -124,10 +124,7 @@ def blend_with_mask(
     fg = foreground.astype(np.float32)
     bg = background.astype(np.float32)
 
-    if mask.ndim == 2:
-        m = mask[:, :, np.newaxis]
-    else:
-        m = mask
+    m = mask[:, :, np.newaxis] if mask.ndim == 2 else mask
 
     result = fg * m + bg * (1.0 - m)
     return np.clip(result, 0, 255).astype(np.uint8)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -123,7 +123,11 @@ RECENT_DIRECTORY_SOURCE = None
 RECENT_DIRECTORY_TARGET = None
 RECENT_DIRECTORY_OUTPUT = None
 
-_ = lambda x: x  # replaced by LanguageManager in init()
+
+def _(x):
+    return x  # replaced by LanguageManager in init()
+
+
 preview_label = None
 preview_slider = None
 source_label = None
@@ -170,10 +174,11 @@ def init(start: Callable[[], None], destroy: Callable[[], None], lang: str) -> c
 def _state_file_path() -> str:
     import platform as _platform
 
-    if _platform.system() == "Windows":
-        base = os.environ.get("APPDATA", os.path.expanduser("~"))
-    else:
-        base = os.path.join(os.path.expanduser("~"), ".config")
+    base = (
+        os.environ.get("APPDATA", os.path.expanduser("~"))
+        if _platform.system() == "Windows"
+        else os.path.join(os.path.expanduser("~"), ".config")
+    )
     config_dir = os.path.join(base, "deep-live-cam")
     os.makedirs(config_dir, exist_ok=True)
     return os.path.join(config_dir, "switch_states.json")
@@ -564,15 +569,16 @@ def _create_switch(
 
     if attr.startswith("fp_ui:"):
         key = attr[len("fp_ui:") :]
-        command = lambda: (
-            update_tumbler(key, value_var.get()),
-            save_switch_states(),
-        )
+
+        def command():
+            update_tumbler(key, value_var.get())
+            save_switch_states()
+
     else:
-        command = lambda: (
-            setattr(modules.globals, attr, value_var.get()),
-            save_switch_states(),
-        )
+
+        def command():
+            setattr(modules.globals, attr, value_var.get())
+            save_switch_states()
 
     switch = ctk.CTkSwitch(
         parent,
@@ -1396,10 +1402,11 @@ def swap_faces_paths() -> None:
 
 def capture_target_from_camera() -> None:
     """Open a live camera preview window with a Capture button."""
-    if platform.system() == "Windows":
-        cap = cv2.VideoCapture(_selected_camera_index, cv2.CAP_MSMF)
-    else:
-        cap = cv2.VideoCapture(_selected_camera_index)
+    cap = (
+        cv2.VideoCapture(_selected_camera_index, cv2.CAP_MSMF)
+        if platform.system() == "Windows"
+        else cv2.VideoCapture(_selected_camera_index)
+    )
     if not cap.isOpened():
         update_status("Failed to open camera.")
         return

--- a/modules/ui_webcam.py
+++ b/modules/ui_webcam.py
@@ -351,7 +351,6 @@ def _processing_thread_func(
     tick_update_interval = 0.5
     prev_processed_frame = None
     rife_warned = False
-    half_rate_warned = False
     frame_counter = 0
     enhancer_frame_counter = 0
     prev_enhanced_faces = None  # faces from the last submitted enhancement frame
@@ -531,10 +530,7 @@ def _processing_thread_func(
                 # In half-rate mode, generate exactly keyframe_interval-1 intermediates so
                 # every skip slot between consecutive keyframes gets a smooth interpolated
                 # frame. Outside half-rate mode, honour the user's rife_multiplier setting.
-                if half_rate_enabled:
-                    multiplier = keyframe_interval
-                else:
-                    multiplier = snap_rife_multiplier
+                multiplier = keyframe_interval if half_rate_enabled else snap_rife_multiplier
                 intermediates = interpolate_frame_pair(
                     prev_processed_frame,
                     temp_frame,
@@ -559,10 +555,7 @@ def _processing_thread_func(
 
         # Update prev_processed_frame on keyframes; keep unchanged on skip frames
         if not skip_face_processing:
-            if rife_enabled or half_rate_enabled:
-                prev_processed_frame = temp_frame.copy()
-            else:
-                prev_processed_frame = None
+            prev_processed_frame = temp_frame.copy() if rife_enabled or half_rate_enabled else None
         # else (skip frame): prev_processed_frame stays set to the last keyframe output
 
         # Track processing tick rate (written to shared holder; read by display loop)
@@ -651,9 +644,8 @@ def create_webcam_preview(camera_index: int, config: ProcessingConfig | None = N
         PREVIEW.deiconify()
 
     # Start virtual camera if enabled
-    if config.virtual_cam:
-        if not virtual_cam.start(PREVIEW_DEFAULT_WIDTH, PREVIEW_DEFAULT_HEIGHT):
-            update_status("Virtual camera failed to start — check logs")
+    if config.virtual_cam and not virtual_cam.start(PREVIEW_DEFAULT_WIDTH, PREVIEW_DEFAULT_HEIGHT):
+        update_status("Virtual camera failed to start — check logs")
 
     # Queues for decoupling capture from processing and processing from display.
     # Small maxsize ensures we always work on recent frames and drop stale ones.

--- a/modules/ui_webcam.py
+++ b/modules/ui_webcam.py
@@ -204,10 +204,7 @@ def _enhancement_process_fn(inp):
     faces = inp["faces"]
     map_faces = inp["map_faces"]
 
-    if map_faces:
-        enhanced = processor.process_frame_v2(frame)
-    else:
-        enhanced = processor.process_frame(None, frame, faces=faces)
+    enhanced = processor.process_frame_v2(frame) if map_faces else processor.process_frame(None, frame, faces=faces)
 
     return {"frame": enhanced, "seq": inp["seq"]}
 

--- a/tests/test_download_model_if_needed.py
+++ b/tests/test_download_model_if_needed.py
@@ -52,7 +52,9 @@ def test_on_status_called_when_downloading(mock_exists, mock_download):
 
     mock_exists.side_effect = [False, True]  # missing → found after download
     status_calls = []
-    on_status = lambda msg, name: status_calls.append((msg, name))
+
+    def on_status(msg, name):
+        status_calls.append((msg, name))
 
     result = download_model_if_needed(
         "model.onnx",
@@ -74,7 +76,9 @@ def test_on_status_called_on_download_failure(mock_exists, mock_download):
 
     mock_exists.return_value = False
     status_calls = []
-    on_status = lambda msg, name: status_calls.append((msg, name))
+
+    def on_status(msg, name):
+        status_calls.append((msg, name))
 
     result = download_model_if_needed(
         "model.onnx",

--- a/tests/test_enhancer_skip.py
+++ b/tests/test_enhancer_skip.py
@@ -122,7 +122,6 @@ class TestFrameHoldOnSkip:
         enhanced_result = self._make_frame(75)
         prev_enhanced = None
 
-        skip_enhancer = False
         # Simulate: enhancer runs and produces enhanced_result
         result = enhanced_result
         prev_enhanced = result.copy()
@@ -152,14 +151,12 @@ class TestEnhancerSkipIndependentOfHalfRate:
         """Half-rate and enhancer skip use separate counters and don't interfere."""
         keyframe_interval = 2
         enhancer_interval = 3
-        frame_counter = 0
         enhancer_counter = 0
 
         half_rate_skips = []
         enhancer_skips = []
 
-        for _ in range(9):
-            frame_counter += 1
+        for frame_counter in range(1, 10):
             hr_skip = self._half_rate_skip(frame_counter, keyframe_interval)
             half_rate_skips.append(hr_skip)
 

--- a/tests/test_enhancer_skip.py
+++ b/tests/test_enhancer_skip.py
@@ -101,10 +101,7 @@ class TestFrameHoldOnSkip:
         current_frame = self._make_frame(100)
 
         skip_enhancer = True
-        if skip_enhancer and prev_enhanced is not None:
-            result = prev_enhanced
-        else:
-            result = current_frame
+        result = prev_enhanced if (skip_enhancer and prev_enhanced is not None) else current_frame
 
         assert np.array_equal(result, prev_enhanced)
         assert not np.array_equal(result, current_frame)
@@ -115,10 +112,8 @@ class TestFrameHoldOnSkip:
         current_frame = self._make_frame(100)
 
         skip_enhancer = True  # would skip, but no cache available
-        if skip_enhancer and prev_enhanced is not None:
-            result = prev_enhanced
-        else:
-            result = current_frame  # falls through to actual enhancement
+        # falls through to actual enhancement when prev_enhanced is None
+        result = prev_enhanced if (skip_enhancer and prev_enhanced is not None) else current_frame
 
         assert np.array_equal(result, current_frame)
 

--- a/tests/test_status_bus.py
+++ b/tests/test_status_bus.py
@@ -149,7 +149,7 @@ class TestCoreUsesStatusBus:
         top_level_ui_imports = [
             node
             for node in ast.walk(tree)
-            if isinstance(node, (ast.Import, ast.ImportFrom))
+            if isinstance(node, ast.Import | ast.ImportFrom)
             and (
                 (
                     isinstance(node, ast.Import)

--- a/tests/test_status_bus.py
+++ b/tests/test_status_bus.py
@@ -32,7 +32,10 @@ class TestStatusBusBasics:
 
         bus = StatusBus()
         received = []
-        cb = lambda m, c: received.append(m)
+
+        def cb(m, c):
+            received.append(m)
+
         bus.subscribe(cb)
         bus.unsubscribe(cb)
         bus.publish("should not arrive", "test")
@@ -118,7 +121,10 @@ class TestCoreUsesStatusBus:
         from modules.status_bus import BUS
 
         received = []
-        cb = lambda msg, caller: received.append((msg, caller))
+
+        def cb(msg, caller):
+            received.append((msg, caller))
+
         BUS.subscribe(cb)
         try:
             modules.globals.headless = True  # avoid UI calls


### PR DESCRIPTION
Fixes non-auto-fixable ruff warnings from issue #106.

E731 (lambda assigned to variable → def):
- modules/ui.py: convert `_ = lambda x: x` placeholder to `def _(x)`
- modules/ui.py: convert `command = lambda: (...)` in _create_switch to `def command()`
- tests/test_status_bus.py: convert lambda cb assignments to def
- tests/test_download_model_if_needed.py: convert lambda on_status to def

SIM108 (if/else variable assignment → ternary):
- modules/ui.py: _state_file_path Windows/Linux base path selection
- modules/ui.py: capture_target_from_camera VideoCapture backend selection
- modules/paste_back.py: blend_with_mask mask dimension expansion
- modules/ui_webcam.py: _enhancement_process_fn map_faces branch
- tests/test_enhancer_skip.py: frame hold logic in two test cases

No behavioral changes — style-only fixes.

Closes #106

Generated with [Claude Code](https://claude.ai/code)